### PR TITLE
Add some inttypes.h/stdint.h to workaround some boost versions.

### DIFF
--- a/host/include/uhd/types/serial.hpp
+++ b/host/include/uhd/types/serial.hpp
@@ -18,6 +18,7 @@
 #ifndef INCLUDED_UHD_TYPES_SERIAL_HPP
 #define INCLUDED_UHD_TYPES_SERIAL_HPP
 
+#include <inttypes.h>
 #include <uhd/config.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/cstdint.hpp>

--- a/host/include/uhd/utils/msg_task.hpp
+++ b/host/include/uhd/utils/msg_task.hpp
@@ -18,6 +18,7 @@
 #ifndef INCLUDED_UHD_UTILS_MSG_TASK_HPP
 #define INCLUDED_UHD_UTILS_MSG_TASK_HPP
 
+#include <stdint.h>
 #include <uhd/config.hpp>
 #include <uhd/transport/zero_copy.hpp>
 #include <boost/shared_ptr.hpp>

--- a/host/lib/usrp/x300/x300_regs.hpp
+++ b/host/lib/usrp/x300/x300_regs.hpp
@@ -18,6 +18,8 @@
 #ifndef INCLUDED_X300_REGS_HPP
 #define INCLUDED_X300_REGS_HPP
 
+#include <stdint.h>
+#include <inttypes.h>
 #include <boost/cstdint.hpp>
 
 #define TOREG(x) ((x)*4)

--- a/host/tests/time_spec_test.cpp
+++ b/host/tests/time_spec_test.cpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <inttypes.h>
 #include <boost/test/unit_test.hpp>
 #include <uhd/types/time_spec.hpp>
 #include <boost/foreach.hpp>


### PR DESCRIPTION
It's slightly inelegant to add these C-style includes, but they've been
standardized for a long time.  Sadly some versions of boost (including the
one in current Debian) cannot compile this package unless these extra
includes are added.
