### PR TITLE
dbsrx2: Fixed rounding bug when tuning close to integer ratio transition...

### DIFF
--- a/host/lib/usrp/dboard/db_dbsrx2.cpp
+++ b/host/lib/usrp/dboard/db_dbsrx2.cpp
@@ -258,6 +258,10 @@ double dbsrx2::set_lo_freq(double target_freq){
     N = (target_freq*R*ext_div)/(ref_freq); //actual spec range is (19, 251)
     intdiv = int(std::floor(N)); //  if (intdiv < 19  or intdiv > 251) continue;
     fracdiv = boost::math::iround((N - intdiv)*double(1 << 20));
+    if(fracdiv == (1 << 20)){ //Make sure fracdiv is within range
+	    intdiv++;
+	    fracdiv = 0;
+    }
 
     //calculate the actual freq from the values above
     N = double(intdiv) + double(fracdiv)/double(1 << 20);


### PR DESCRIPTION
If the target LO frequency is close to an integer multiple of the reference frequency, the fractional divide ratio will round to (1 << 20).  This value is too large MAX2112 fractional divide register, resulting in an error in the LO frequency of approximately ref_freq.  GNURadio's float_converter() will often translate 976e6 to 975999999.99999988079071044921875, causing frequent issues when using a USRP1 w/ DBSRX2.  

Added a check for this edge case.
