### PR TITLE
uhd_dump: use LIBS instead of LDFLAGS

### DIFF
--- a/tools/uhd_dump/Makefile
+++ b/tools/uhd_dump/Makefile
@@ -20,7 +20,7 @@ OBJECTS = uhd_dump.o
 
 CFLAGS = -g -O0 -Wall
 
-LDFLAGS = -lpcap -lm
+LIBS = -lpcap -lm
 
 CC = cc
 
@@ -28,7 +28,7 @@ CC = cc
 all: $(BINARIES)
 
 chdr_log: uhd_dump.o chdr_log.o $(INCLUDES)
-	$(CC) $(CFLAGS) -o $@ uhd_dump.o chdr_log.o  $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ uhd_dump.o chdr_log.o  $(LIBS) $(LDFLAGS)
 
 
 


### PR DESCRIPTION
This allows distro override for LDFLAGS and doesn't break the build process.

Signed-off-by: Jaroslav Škarvada jskarvad@redhat.com
