### PR TITLE
chdr-dissector: fix wireshark-1.12 detection

### DIFF
--- a/tools/chdr-dissector/cmake/Modules/FindWireshark.cmake
+++ b/tools/chdr-dissector/cmake/Modules/FindWireshark.cmake
@@ -16,7 +16,7 @@
 # wireshark does not install its library with pkg-config information,
 # so we need to manually find the libraries and headers
 
-FIND_PATH( WIRESHARK_INCLUDE_DIRS epan/column_info.h PATH_SUFFIXES wireshark )
+FIND_PATH( WIRESHARK_INCLUDE_DIRS epan/column.h PATH_SUFFIXES wireshark )
 FIND_LIBRARY( WIRESHARK_LIBRARIES wireshark )
 
 # Report results


### PR DESCRIPTION
The epan/column_info.h is no more there.

Signed-off-by: Jaroslav Škarvada jskarvad@redhat.com
