### PR TITLE
B2x0: added 'no_gpsdo' argument to disable GPSDO querying at creation

### DIFF
--- a/host/docs/gpsdo_b2x0.dox
+++ b/host/docs/gpsdo_b2x0.dox
@@ -51,6 +51,13 @@ oscillator will be phase-locked to the 10MHz GPSDO reference. If the
 GPSDO is not locked to satellites, the VITA time will not be
 initialized.
 
+If you want to disable your GPSDO pass the **no_gpsdo** option as part of the
+device arguments, for example:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.sh}
+uhd_usrp_probe --args "no_gpsdo"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 GPS data is obtained through the **mboard_sensors** interface. To
 retrieve the current GPS time, use the **gps_time** sensor:
 

--- a/host/lib/usrp/b200/b200_impl.cpp
+++ b/host/lib/usrp/b200/b200_impl.cpp
@@ -208,7 +208,7 @@ b200_impl::b200_impl(const device_addr_t &device_addr)
         vid = uhd::cast::hexstr_cast<boost::uint16_t>(device_addr.get("vid"));
     if (device_addr.has_key("pid"))
         pid = uhd::cast::hexstr_cast<boost::uint16_t>(device_addr.get("pid"));
-
+    _gpsdo_enable = ! device_addr.has_key("no_gpsdo");
     std::vector<usb_device_handle::sptr> device_list =
         usb_device_handle::get_device_list(vid, pid);
 
@@ -326,7 +326,7 @@ b200_impl::b200_impl(const device_addr_t &device_addr)
     _async_task_data->gpsdo_uart->write_uart("\n"); //cause the baud and response to be setup
     boost::this_thread::sleep(boost::posix_time::seconds(1)); //allow for a little propagation
 
-    if ((_local_ctrl->peek32(RB32_CORE_STATUS) & 0xff) != B200_GPSDO_ST_NONE)
+    if ((_local_ctrl->peek32(RB32_CORE_STATUS) & 0xff) != B200_GPSDO_ST_NONE && _gpsdo_enable)
     {
         UHD_MSG(status) << "Detecting internal GPSDO.... " << std::flush;
         try

--- a/host/lib/usrp/b200/b200_impl.hpp
+++ b/host/lib/usrp/b200/b200_impl.hpp
@@ -108,6 +108,7 @@ private:
     b200_local_spi_core::sptr _spi_iface;
     boost::shared_ptr<uhd::usrp::adf4001_ctrl> _adf4001_iface;
     uhd::gps_ctrl::sptr _gps;
+    bool _gpsdo_enable;
 
     //transports
     uhd::transport::zero_copy_if::sptr _data_transport;


### PR DESCRIPTION
... because for me, without GPS fix I couldn't use the B210 unless disabled the GPSDO.
