### PR TITLE
Show set_rx_bandwidth units properly in MHz in all examples

### DIFF
--- a/host/examples/rx_ascii_art_dft.cpp
+++ b/host/examples/rx_ascii_art_dft.cpp
@@ -110,9 +110,9 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
     //set the analog frontend filter bandwidth
     if (vm.count("bw")){
-        std::cout << boost::format("Setting RX Bandwidth: %f MHz...") % bw << std::endl;
+        std::cout << boost::format("Setting RX Bandwidth: %f MHz...") % (bw/1e6) << std::endl;
         usrp->set_rx_bandwidth(bw);
-        std::cout << boost::format("Actual RX Bandwidth: %f MHz...") % usrp->get_rx_bandwidth() << std::endl << std::endl;
+        std::cout << boost::format("Actual RX Bandwidth: %f MHz...") % (usrp->get_rx_bandwidth()/1e6) << std::endl << std::endl;
     }
 
     //set the antenna

--- a/host/examples/rx_samples_to_file.cpp
+++ b/host/examples/rx_samples_to_file.cpp
@@ -304,9 +304,9 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
     //set the IF filter bandwidth
     if (vm.count("bw")) {
-        std::cout << boost::format("Setting RX Bandwidth: %f MHz...") % bw << std::endl;
+        std::cout << boost::format("Setting RX Bandwidth: %f MHz...") % (bw/1e6) << std::endl;
         usrp->set_rx_bandwidth(bw);
-        std::cout << boost::format("Actual RX Bandwidth: %f MHz...") % usrp->get_rx_bandwidth() << std::endl << std::endl;
+        std::cout << boost::format("Actual RX Bandwidth: %f MHz...") % (usrp->get_rx_bandwidth()/1e6) << std::endl << std::endl;
     }
 
     //set the antenna

--- a/host/examples/rx_samples_to_udp.cpp
+++ b/host/examples/rx_samples_to_udp.cpp
@@ -93,9 +93,9 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
     //set the analog frontend filter bandwidth
     if (vm.count("bw")){
-        std::cout << boost::format("Setting RX Bandwidth: %f MHz...") % bw << std::endl;
+        std::cout << boost::format("Setting RX Bandwidth: %f MHz...") % (bw/1e6) << std::endl;
         usrp->set_rx_bandwidth(bw);
-        std::cout << boost::format("Actual RX Bandwidth: %f MHz...") % usrp->get_rx_bandwidth() << std::endl << std::endl;
+        std::cout << boost::format("Actual RX Bandwidth: %f MHz...") % (usrp->get_rx_bandwidth()/1e6) << std::endl << std::endl;
     }
 
     //set the antenna

--- a/host/examples/txrx_loopback_to_file.cpp
+++ b/host/examples/txrx_loopback_to_file.cpp
@@ -374,9 +374,9 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
         //set the receive analog frontend filter bandwidth
         if (vm.count("rx-bw")){
-            std::cout << boost::format("Setting RX Bandwidth: %f MHz...") % rx_bw << std::endl;
+            std::cout << boost::format("Setting RX Bandwidth: %f MHz...") % (rx_bw/1e6) << std::endl;
             rx_usrp->set_rx_bandwidth(rx_bw, channel);
-            std::cout << boost::format("Actual RX Bandwidth: %f MHz...") % rx_usrp->get_rx_bandwidth(channel) << std::endl << std::endl;
+            std::cout << boost::format("Actual RX Bandwidth: %f MHz...") % (rx_usrp->get_rx_bandwidth(channel)/1e6) << std::endl << std::endl;
         }
     }
     //set the receive antenna


### PR DESCRIPTION
Many bandwidth parameters are output to the console in the example code. They are output in Hz, but the text says they are in MHz, resulting in output like "56000000.000000 MHz" of bandwidth being reported on the console. Although I wish the B210 had 56 THz of bandwidth, this output is clearly a mistake.  The patch simply divides bandwidths by 1e6 before outputting them to the cout stream so that correct values are output to the console by the examples.