### PR TITLE
only set RF frequency if target_freq is actually set

### DIFF
--- a/host/lib/usrp/multi_usrp.cpp
+++ b/host/lib/usrp/multi_usrp.cpp
@@ -311,7 +311,7 @@ static tune_result_t tune_xx_subdev_and_dsp(
     //------------------------------------------------------------------
     //-- Tune the RF frontend
     //------------------------------------------------------------------
-    rf_fe_subtree->access<double>("freq/value").set(target_rf_freq);
+    if (target_rf_freq) rf_fe_subtree->access<double>("freq/value").set(target_rf_freq);
     const double actual_rf_freq = rf_fe_subtree->access<double>("freq/value").get();
 
     //------------------------------------------------------------------


### PR DESCRIPTION
Hey guys,
attached is a small fix that brings back the old behavior in which the RF frequency is actually not touched if rf_freq_policy=POLICY_NONE. This bug was introduced in 88d8065371f01b61cd14e10e8f9cfd184480f3 because setting the target_rf_freq was moved outside of the switch statement without any condition, so it was also applied if the rf_freq didn't change.

Cheers
Andre