### PR TITLE
Added srecord dependency for building the firmware

### DIFF
--- a/firmware/e300/battery/README.md
+++ b/firmware/e300/battery/README.md
@@ -5,7 +5,7 @@ Welcome to the NI Ettus Research USRP E310/E312 Firmware distribution.
 
 # Dependencies
 
-In order to build you'll *avr-gcc* and *avr-libc*.
+In order to build you'll *avr-gcc*, *avr-libc*, and *srec_cat*.
 
 # Building
 


### PR DESCRIPTION
The srec_cat program is needed to create the fuse files for the AVR firmware.