### PR TITLE
Serialized calls to conversion- Reduces CPU use by ~50% on reads

### DIFF
--- a/host/lib/transport/super_recv_packet_handler.hpp
+++ b/host/lib/transport/super_recv_packet_handler.hpp
@@ -92,22 +92,14 @@ public:
     }
 
     ~recv_packet_handler(void){
-        _task_barrier.interrupt();
-        _task_handlers.clear();
     }
 
     //! Resize the number of transport channels
     void resize(const size_t size){
         if (this->size() == size) return;
-        _task_handlers.clear();
         _props.resize(size);
         //re-initialize all buffers infos by re-creating the vector
         _buffers_infos = std::vector<buffers_info_type>(4, buffers_info_type(size));
-        _task_barrier.resize(size);
-        _task_handlers.resize(size);
-        for (size_t i = 1/*skip 0*/; i < size; i++){
-            _task_handlers[i] = task::make(boost::bind(&recv_packet_handler::converter_thread_task, this, i));
-        };
     }
 
     //! Get the channel width of this handler
@@ -663,7 +655,10 @@ private:
         _convert_bytes_to_copy = bytes_to_copy;
 
         //perform N channels of conversion
-        converter_thread_task(0);
+        for (size_t xx = 0; xx < buffs.size(); xx++)
+        {
+           converter_thread_task(xx);
+        }
 
         //update the copy buffer's availability
         info.data_bytes_to_copy -= bytes_to_copy;
@@ -677,14 +672,10 @@ private:
     }
 
     /*******************************************************************
-     * Perform one thread's work of the conversion task.
-     * The entry and exit use a dual synchronization barrier,
-     * to wait for data to become ready and block until completion.
+     * Perform the conversion task on one buffer's data.
      ******************************************************************/
     UHD_INLINE void converter_thread_task(const size_t index)
     {
-        _task_barrier.wait();
-
         //shortcut references to local data structures
         buffers_info_type &buff_info = get_curr_buffer_info();
         per_buffer_info_type &info = buff_info[index];
@@ -708,13 +699,9 @@ private:
         if (buff_info.data_bytes_to_copy == _convert_bytes_to_copy){
             info.buff.reset(); //effectively a release
         }
-
-        if (index == 0) _task_barrier.wait_others();
     }
 
     //! Shared variables for the worker threads
-    reusable_barrier _task_barrier;
-    std::vector<task::sptr> _task_handlers;
     size_t _convert_nsamps;
     const rx_streamer::buffs_type *_convert_buffs;
     size_t _convert_buffer_offset_bytes;


### PR DESCRIPTION
Tested on Intel Celeron (J1900 and N3150). Without these changes, attempts to stream with higher bandwidths fail, and attempts to stream dual channels will fail with relatively low bandwidths (~12MHz).

With these changes, higher bandwidth streaming is much more reliable on Celeron processors