### PR TITLE
C API: Implement set_time_source_out and fix typo

### DIFF
--- a/host/lib/usrp/usrp_c.cpp
+++ b/host/lib/usrp/usrp_c.cpp
@@ -613,6 +613,16 @@ uhd_error uhd_usrp_set_clock_source_out(
     )
 }
 
+uhd_error uhd_usrp_set_time_source_out(
+    uhd_usrp_handle h,
+    bool enb,
+    size_t mboard
+){
+    UHD_SAFE_C_SAVE_ERROR(h,
+        USRP(h)->set_time_source_out(enb, mboard);
+    )
+}
+
 uhd_error uhd_usrp_get_num_mboards(
     uhd_usrp_handle h,
     size_t *num_mboards_out
@@ -1489,7 +1499,7 @@ uhd_error uhd_usrp_write_register(
     )
 }
 
-uhd_error uhd_usrp_write_register(
+uhd_error uhd_usrp_read_register(
     uhd_usrp_handle h,
     const char* path,
     uint32_t field,


### PR DESCRIPTION
Add missing `set_time_source_out` function, which is declared but not implemented.

Note that before this commit, there were _two_ functions called `uhd_usrp_write_register`.

I did a quick compile check, but do not consider this as tested.
