### PR TITLE
Rfnoc: Exposed analog lowpass bandwidth option for rfnoc radio source

### DIFF
--- a/host/include/uhd/rfnoc/radio_ctrl.hpp
+++ b/host/include/uhd/rfnoc/radio_ctrl.hpp
@@ -150,6 +150,20 @@ public:
      */
     virtual double set_rx_gain(const double gain, const size_t chan) = 0;
 
+    /*! Return the analog filter bandwidth channel \p chan
+     *
+     * \return The actual bandwidth value
+     */
+    // virtual double get_rx_bandwidth(const double bandwidth, const size_t chan) = 0;
+
+    /*! Set the analog filter bandwidth channel \p chan
+     *
+     * This function will attempt to set the analog bandwidth.
+     *
+     * \return The actual bandwidth value
+     */
+    virtual double set_rx_bandwidth(const double bandwidth, const size_t chan) = 0;
+
     /*! Sets the time in the radio's timekeeper to the given value.
      *
      * Note that there is a non-deterministic delay between calling this

--- a/host/lib/rfnoc/radio_ctrl_impl.cpp
+++ b/host/lib/rfnoc/radio_ctrl_impl.cpp
@@ -195,6 +195,11 @@ double radio_ctrl_impl::set_rx_gain(const double gain, const size_t chan)
     return _rx_gain[chan] = gain;
 }
 
+double radio_ctrl_impl::set_rx_bandwidth(const double bandwidth, const size_t chan)
+{
+    return _rx_bandwidth[chan] = bandwidth;
+}
+
 void radio_ctrl_impl::set_time_sync(const uhd::time_spec_t &time)
 {
     _time64->set_time_sync(time);
@@ -233,6 +238,11 @@ double radio_ctrl_impl::get_tx_gain(const size_t chan) /* const */
 double radio_ctrl_impl::get_rx_gain(const size_t chan) /* const */
 {
     return _rx_gain[chan];
+}
+
+double radio_ctrl_impl::get_rx_bandwidth(const size_t chan) /* const */
+{
+    return _rx_bandwidth[chan];
 }
 
 /***********************************************************************

--- a/host/lib/rfnoc/radio_ctrl_impl.hpp
+++ b/host/lib/rfnoc/radio_ctrl_impl.hpp
@@ -60,6 +60,7 @@ public:
     virtual double set_rx_frequency(const double freq, const size_t chan);
     virtual double set_tx_gain(const double gain, const size_t chan);
     virtual double set_rx_gain(const double gain, const size_t chan);
+    virtual double set_rx_bandwidth(const double bandwidth, const size_t chan);
 
     virtual double get_rate() const;
     virtual std::string get_tx_antenna(const size_t chan) /* const */;
@@ -68,6 +69,7 @@ public:
     virtual double get_rx_frequency(const size_t) /* const */;
     virtual double get_tx_gain(const size_t) /* const */;
     virtual double get_rx_gain(const size_t) /* const */;
+    virtual double get_rx_bandwidth(const size_t) /* const */;
 
     void set_time_now(const time_spec_t &time_spec);
     void set_time_next_pps(const time_spec_t &time_spec);
@@ -199,6 +201,7 @@ private:
     std::map<size_t, double> _rx_freq;
     std::map<size_t, double> _tx_gain;
     std::map<size_t, double> _rx_gain;
+    std::map<size_t, double> _rx_bandwidth;
 
     std::vector<bool> _continuous_streaming;
 }; /* class radio_ctrl_impl */

--- a/host/lib/usrp/e300/e3xx_radio_ctrl_impl.cpp
+++ b/host/lib/usrp/e300/e3xx_radio_ctrl_impl.cpp
@@ -188,6 +188,13 @@ double e3xx_radio_ctrl_impl::set_rx_gain(const double gain, const size_t chan)
     return radio_ctrl_impl::set_rx_gain(new_gain, chan);
 }
 
+double e3xx_radio_ctrl_impl::set_rx_bandwidth(const double bandwidth, const size_t chan)
+{
+    const std::string fe_side = (chan == 0) ? "A" : "B";
+    double new_bw = _tree->access<double>(fs_path("dboards/A/rx_frontends/" + fe_side + "/bandwidth/value")).set(bandwidth).get();
+    return radio_ctrl_impl::set_rx_bandwidth(new_bw, chan);
+}
+
 double e3xx_radio_ctrl_impl::get_tx_gain(const size_t chan)
 {
     const std::string fe_side = (chan == 0) ? "A" : "B";
@@ -198,6 +205,12 @@ double e3xx_radio_ctrl_impl::get_rx_gain(const size_t chan)
 {
     const std::string fe_side = (chan == 0) ? "A" : "B";
     return _tree->access<double>(fs_path("dboards/A/rx_frontends/" + fe_side + "/gains/PGA/value")).get();
+}
+
+double e3xx_radio_ctrl_impl::get_rx_bandwidth(const size_t chan)
+{
+    const std::string fe_side = (chan == 0) ? "A" : "B";
+    return _tree->access<double>(fs_path("dboards/A/rx_frontends/" + fe_side + "/bandwidth/value")).get();
 }
 
 std::vector<std::string> e3xx_radio_ctrl_impl::get_gpio_banks() const

--- a/host/lib/usrp/e300/e3xx_radio_ctrl_impl.hpp
+++ b/host/lib/usrp/e300/e3xx_radio_ctrl_impl.hpp
@@ -50,9 +50,11 @@ public:
 
     double set_tx_gain(const double gain, const size_t chan);
     double set_rx_gain(const double gain, const size_t chan);
+    double set_rx_bandwidth(const double bandwidth, const size_t chan);
 
     double get_tx_gain(const size_t chan);
     double get_rx_gain(const size_t chan);
+    double get_rx_bandwidth(const size_t chan);
 
     std::vector<std::string> get_gpio_banks() const;
     void set_gpio_attr(const std::string &bank, const std::string &attr, const uint32_t value, const uint32_t mask);

--- a/host/lib/usrp/x300/x300_radio_ctrl_impl.cpp
+++ b/host/lib/usrp/x300/x300_radio_ctrl_impl.cpp
@@ -229,6 +229,20 @@ double x300_radio_ctrl_impl::get_rx_frequency(const size_t chan)
     ).get();
 }
 
+double x300_radio_ctrl_impl::set_rx_bandwidth(const double bandwidth, const size_t chan)
+{
+    return _tree->access<double>(
+        fs_path("dboards" / _radio_slot / "rx_frontends" / _rx_fe_map.at(chan).db_fe_name / "bandwidth" / "value")
+    ).set(bandwidth).get();
+}
+
+double x300_radio_ctrl_impl::get_rx_bandwidth(const size_t chan)
+{
+    return _tree->access<double>(
+        fs_path("dboards" / _radio_slot / "rx_frontends" / _rx_fe_map.at(chan).db_fe_name / "bandwidth" / "value")
+    ).get();
+}
+
 double x300_radio_ctrl_impl::set_tx_gain(const double gain, const size_t chan)
 {
     //TODO: This is extremely hacky!

--- a/host/lib/usrp/x300/x300_radio_ctrl_impl.hpp
+++ b/host/lib/usrp/x300/x300_radio_ctrl_impl.hpp
@@ -56,8 +56,10 @@ public:
 
     double set_tx_frequency(const double freq, const size_t chan);
     double set_rx_frequency(const double freq, const size_t chan);
+    double set_rx_bandwidth(const double bandwidth, const size_t chan);
     double get_tx_frequency(const size_t chan);
     double get_rx_frequency(const size_t chan);
+    double get_rx_bandwidth(const size_t chan);
 
     double set_tx_gain(const double gain, const size_t chan);
     double set_rx_gain(const double gain, const size_t chan);


### PR DESCRIPTION
This provides the gnuradio-companion software hooks to control the AD9361 lowpass bandwidth setting. 

Note this option is currently exposed in the UHD USRP Source GRC block, but not yet exposed in the RFNoC Radio Source. 

I've submitted a companion PR (ejk-rfnoc-analogbandpass) to the gr-ettus repo for the block changes. 