### PR TITLE
fir_block_ctrl_impl: Added a register write that seems to fix the FIR…

### DIFF
--- a/host/lib/rfnoc/fir_block_ctrl_impl.cpp
+++ b/host/lib/rfnoc/fir_block_ctrl_impl.cpp
@@ -62,6 +62,11 @@ public:
             taps.resize(_n_taps, 0);
         }
 
+        // Note- It appears the tap load process does not take affect until the NEXT time
+        // we write to SR_CONFIG. But, if we call SR_CONFIG before (and after) reloading taps,
+        // it seems to be happy. Not sure why. I'd be happy to find a different solution.
+        sr_write(SR_CONFIG, 0);
+
         // Write taps via the reload bus
         for (size_t i = 0; i < taps.size() - 1; i++) {
             sr_write(SR_RELOAD, uint32_t(taps[i]));


### PR DESCRIPTION
… tap load problem

Hey, this is my fix to the FIR tap load problem in the FIR block. Jonathon mentioned you were having problems finding a way to load the Xilinx FIR IP reliably, so I thought I'd share. It's just the hack that worked for me, but probably not tested well enough to be confident it fixes all the error cases you saw. 