### PR TITLE
Definitions of MASK_GPIO_SHDN_SW and GPIO_AUX_PWR_ON Errors

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -1,0 +1,139 @@
+# UHD Coding Standards
+
+Note: This file applies to all code within the UHD repository, not just for
+code that is actually part of the UHD library.
+
+## Preamble
+
+To quote R. W. Emerson: "A foolish consistency is the hobgoblin of little minds,
+adored by little statesmen and philosophers and divines". Ignoring the little
+statesmen for a minute, these coding standards are here to make our life
+*easier*, not simply add additional rules. They are meant as additional guidance
+for developers, and are not meant to be interpreted as law.
+
+So, ultimately, it is up to the developer to decide how much these guidelines
+should be heeded when writing code, and up to reviewers how much they are
+relevant to new submissions.
+That said, a consistent codebase is easier to maintain, read, understand, and
+extend. Choosing personal preferences over these coding guidelines is not a
+helpful move for the team and future maintainability of the UHD codebase.
+
+## General Coding Guidelines
+
+* Never submit code with trailing whitespace.
+* Code layout: We use 4 spaces for indentation levels, and never tabs.
+* Code is read more often than it's written. Code readability is thus something
+  worth optimizing for.
+* Try and keep line lengths to 79 characters, unless readability suffers. We
+  often have to do fun things like SSH into machines and edit code in a
+  terminal, and do side-by-side views of code on small-ish screens, so this is
+  actually pretty helpful.
+* Go crazy with log messages. Trace-level log messages in particular can be
+  used copiously and freely (unless in rare cases where the can interfere with
+  performance). Note that in C++, we have the option of fully compiling out
+  trace-level messages (and even higher levels).
+
+## C++-specific Guidelines
+
+* Use Doxygen doc-blocks copiously.
+* All things equal, prefer standard C++ constructs over Boost constructs (see
+  also Boost guidelines).
+* Given the option, prefer C++ lambdas over std::bind, and just don't use
+  boost::bind if you can.
+* `size_t` is the correct container for all indexing of C++ structures (such
+  as vectors). But keep in mind that the size of `size_t` is
+  *platform-dependent*!
+* Use size-specific types whenever interacting with hardware (`int32_t`, etc.).
+  It's very easy to get bitten by incorrect sizes.
+* Include include files in the following order: Local headers, other
+  UHD headers, 3rd-party library headers, Boost headers, standard headers.
+  The rationale is to include from most to least specific. This is the best way
+  to catch missing includes (if you were to include the standard header first,
+  it would be available to all include files that come later. If they need that
+  standard header too, they should be including it themselves).
+  Example:
+
+```cpp
+#include "x300_specific.hpp"
+#include <uhd/utils/log.hpp>
+#include <libusb/foo.hpp>
+#include <boost/shared_ptr.hpp>
+#include <mutex>
+```
+
+* Feel free to use modern C/C++ features even if they were not used before.
+  Make sure they work with the compilers and dependencies which are set for the
+  version of UHD the commit will be made upon. The Ettus CI system will be able
+  to confirm this.
+  For interesting new features, use 'anchor commits', which describe clearly
+  which new feature was used. They can be used as a reference for other
+  developers. Example:
+
+```
+commit 9fe731cc371efee7f0051186697e611571c5b41b
+Author: Andrej Rode <andrej.rode@ettus.com>
+Date:   Tue Nov 22 16:19:38 2016 -0800
+
+    utils: uhd_find_devices display one device for each unique serial found
+    
+    Note: This also is the first precedent for the usage of the 'auto' keyword
+    in UHD. Commits past this one will also be able to use 'auto'.
+    
+    Reviewed-By: Martin Braun <martin.braun@ettus.com>
+```
+
+
+## Boost-specific Guidelines
+
+* Avoid Boost where possible.
+* Don't use Boost's sleep functions. Prefer `std::chrono` functions.
+* When using `boost::assign::list_of` or `boost::assign::map_list_of`, make
+  sure to explicitly cast to the appropriate container (even better: Avoid
+  `boost::assign`, maybe use std initializer lists where possible):
+
+```cpp
+std::vector<std::string> foo =
+    boost::assign::list_of<std::string> // Explicitly list the type (in this
+        ("string1")                     // case, std::string). Then list all
+        ("string2")                     // the items (string1, string2, etc).
+        ("etc")
+    .to_container(foo); // Finally, call conversion routine explicitly.
+// Same for maps:
+std::map<std::string, std::string> bar =
+    boost::assign::map_list_of<std::string, std::string>
+        ("a", "b")
+        ("c", "d")
+        ("etc", "etc")
+    .to_container(bar);
+```
+
+
+## Python-specific Guidelines
+
+* Keep Python code compatible with Py2k and Py3k. There are plenty of tools to
+  aid with this, such as `futurize`.
+* Follow the suggestions in PEP8 (https://www.python.org/dev/peps/pep-0008/)
+  and PEP257 (https://www.python.org/dev/peps/pep-0257/). The former is about
+  code layout in general, the latter about docstrings.
+* Pylint is good tool for helping with following code guidelines. It's very
+  fussy though, so don't get too worked up about following its suggestions.
+
+
+## Revision Control Hygiene
+
+* In this repository, we almost always use fast-forward merges, and no merge
+  commits.
+* Prefix all commit messages with the section of code they apply to (Example:
+  "x300: Fixed overflow at full moon"
+* Keep the subject line of a git commit short and concise (so that
+  `git log --oneline` is actually useful), and follow up in greater detail in
+  the body of the commmit message. The body is separated from the subject line
+  with one blank line.
+* Avoid long lines in commit messages (standard is 50 characters for subject,
+  and 72 characters for body).
+* Avoid refactoring, whitespace cleanup, or fixing code to match coding
+  guidelines in the same commit as modifying behaviour. Prefer dedicated
+  cleanup commits.
+* Remember that we ship git repositories, not just code. This means every
+  commit is part of our product and should be treated as such.
+

--- a/firmware/fx3/b200/b200_main.h
+++ b/firmware/fx3/b200/b200_main.h
@@ -32,8 +32,8 @@
  * that GPIOs < 32 are configured without the use of masks. */
 #define MASK_GPIO_PROGRAM_B         (uint32_t)(1 << (GPIO_PROGRAM_B - 32))
 #define MASK_GPIO_INIT_B            (uint32_t)(1 << (GPIO_INIT_B - 32))
-#define MASK_GPIO_AUX_PWR_ON        (uint32_t)(1 << (GPIO_FX3_SCLK - 32))
-#define MASK_GPIO_SHDN_SW           (uint32_t)(1 << (GPIO_FX3_SCLK - 32))
+#define MASK_GPIO_AUX_PWR_ON        (uint32_t)(1 << (GPIO_AUX_PWR_ON - 32))
+#define MASK_GPIO_SHDN_SW           (uint32_t)(1 << (GPIO_SHDN_SW - 32))
 #define MASK_GPIO_FX3_SCLK          (uint32_t)(1 << (GPIO_FX3_SCLK - 32))
 #define MASK_GPIO_FX3_CE            (uint32_t)(1 << (GPIO_FX3_CE - 32))
 #define MASK_GPIO_FX3_MISO          (uint32_t)(1 << (GPIO_FX3_MISO - 32))

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -341,8 +341,8 @@ UHD_INSTALL(FILES
 #{{{IMG_SECTION
 # This section is written automatically by /images/create_imgs_package.py
 # Any manual changes in here will be overwritten.
-SET(UHD_IMAGES_MD5SUM "0afdbe84eaa54edc6a405bce426c28ed")
-SET(UHD_IMAGES_DOWNLOAD_SRC "uhd-images_003.010.002.000-rc1.zip")
+SET(UHD_IMAGES_MD5SUM "8e6e5edab697fa7e3c63c612ba6f79f5")
+SET(UHD_IMAGES_DOWNLOAD_SRC "uhd-images_003.010.002.000-release.zip")
 #}}}
 
 ########################################################################

--- a/host/cmake/debian/changelog
+++ b/host/cmake/debian/changelog
@@ -1,3 +1,35 @@
+uhd (3.10.2.0-0ubuntu1) trusty; urgency=low
+
+  * multi_usrp: Fixed get_normalized_tx_gain.
+  * E300: Fix for streamer recreation issue. Reduced minimum timeout, fixed
+          potential race condition.
+  * X300: Fix for network discovery, will now return early when correct serial is
+          found. Fixed issue with DAC sync. All async messages now go through
+          single DMA channel on PCIe. Improved TX performance. Fixed page size
+          acquisition for PCIe. Fixed some FW communication errors. Improved flow
+          control. Removed MTU throttling. Legacy compat falls back to min spp
+          for mixed transport types.
+  * CBX: Fixed LO LPF behaviour in 1.5-2 GHz range.
+  * UBX: Fixed dtor SIGABRT issue. Better error handling for various dboard clock
+         rates.
+  * TwinRX: Added LO reimport feature.
+  * GPSDO: Improved detection. Improved query_gpsdo sensor.
+  * RFNoC: Fixed issue with DDC and DUC command tick rate.
+  * UHD: Fixed potential memory leak in tasks. Fixed get_normalized_tx_gain().
+         Fixed default socket buffer size to honor MTU.
+  * Examples: Added channel param to samps to/from file. sync_to_gps exits
+              instead of uncaught throw. latency_test improved output. Use
+              next_pps in test_clock_synch. Added TwinRX FHSS example.
+  * Utils: Modified behaviour of uhd_images_downloader so it won't delete dirs
+           when using -i
+  * Tools: Updates to CHDR dissector. Added set_time_source_out(). Fixed LO API.
+  * C API: Fixed some missing fields in USRP info.
+  * Docs: Many minor fixes. Fixed Doxygen warnings related to /* in files.
+  * CMake: Fixed GCC 4.4 compilation issue. Added ability to specify package
+           names.
+
+ -- Ettus Research <packages@ettus.com>  Mon, 31 Jul 2017 02:37:48 -0800
+
 uhd (3.10.1.1-0ubuntu1) trusty; urgency=low
 
   - Docs: The protocol for Gen-3 devices is now consistently referred to as CHDR.

--- a/host/docs/c_api.dox
+++ b/host/docs/c_api.dox
@@ -4,17 +4,34 @@
 
 \section c_api_intro Introduction
 
-Alongside its C++ API, UHD provides a C API wrapper for the uhd::usrp::multi_usrp and
-uhd::usrp_clock::multi_usrp_clock classes, as well as their associated classes and
-structs. Other important UHD functions are also included in this API. To use this
-API, simply:
+Alongside its C++ API, UHD provides a C API wrapper for the
+uhd::usrp::multi_usrp and uhd::usrp_clock::multi_usrp_clock classes, as well as
+their associated classes and structs. Other important UHD functions are also
+included in this API. To use this API, simply:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 #include <uhd.h>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-...and all UHD C-level structs and functions will be available to you. The sections below
-give more detail on the key features of the C API.
+...and all UHD C-level structs and functions will be available to you. The
+sections below give more detail on the key features of the C API.
+
+Keep in mind that the C-API is a wrapper around the C++ API, so performance can
+never exceed that of the C++ API.
+
+\subsection c_api_philosophy API Philosophy
+
+The C API was designed to mirror the C++ API as closely as possible. This means
+that most API calls are mapped 1:1 from C++ to C, and the documentation for the
+C++ API can still be useful and should be considered when using the C API.
+For example, the uhd_usrp_set_rx_antenna() and
+uhd::multi_usrp::set_rx_antenna() calls do the same thing under the hood, and
+thus, if the behaviour of the C API call is unclear, consulting the
+corresponding C++ API call documentation can be helpful.
+
+There are some C++ concepts that don't map into C easily, though. Among those
+are object storage, which is solved by using handles (see \ref c_api_handles)
+and exceptions, which are translated into error codes (see \ref c_api_errorcode).
 
 \subsection c_api_handles C-Level Handles
 
@@ -28,7 +45,7 @@ terminates, you must pass the handle into its free() function, or your program w
 leak. The example below shows the proper usage of an RX metadata handle over the course of its
 lifetime, from instantiation to destruction.
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 uhd_rx_metadata_handle md;
 uhd_rx_metadata_make(&md);
 

--- a/host/docs/rd_testing.dox
+++ b/host/docs/rd_testing.dox
@@ -45,10 +45,11 @@ following).
    `uhd_usrp_probe` and verify that the GPSDO is correctly reported. Power down
    the device before connecting the peripheral. The GPSDO must be reported
    found, and no error or warning must be printed.
-3. Without connecting the GPS antenna input, run `query_gpsdo_sensors`. To pass,
-   it must report the GPSDO as found, lock to the external reference, but then
-   report not being locked to GPS. The tool will report a valid GPS time, and
-   a string such as "GPS and UHD Device time are aligned" in case of success.
+3. OCXO only: Without connecting the GPS antenna input, run
+   `query_gpsdo_sensors`. To pass, it must report the GPSDO as found, lock to
+   the external reference, but then report not being locked to GPS. The tool
+   will report a valid GPS time, and a string such as "GPS and UHD Device time
+   are aligned" in case of success.
 4. Connect a GPS antenna to the input and make sure it is in a position to
    receive GPS satellite data. Confirm that GPS lock is reported using
    `query_gpsdo_sensors` within 20 minutes of connecting the antenna.

--- a/host/docs/uhd.dox
+++ b/host/docs/uhd.dox
@@ -10,6 +10,7 @@ publically available symbol in the UHD namespace.
 Some additional pages on developing UHD are also available here:
 
 \li \subpage page_coding
+\li \subpage page_c_api
 \li \subpage page_converters
 \li \subpage page_stream
 \li \subpage page_rtp


### PR DESCRIPTION
MASK_GPIO_SHDN_SW ( GPIO[52] ) should be shifted by "GPIO_SHDN_SW" but "GPIO_FX3_SCLK ".
Otherwise GPIOs of FX3 will initial GPIO_FX3_SCLK ( GPIO[53] ) as GPIO and SPI respectively. 
It will make GPIO[53] conflict between SPI and GPIO, and SHDN_SW will not work properly as a power switch.