### PR TITLE
Make uhd_rx_streamer_last_error use appropriate SAFE_C macro.

### DIFF
--- a/host/lib/usrp/usrp_c.cpp
+++ b/host/lib/usrp/usrp_c.cpp
@@ -156,7 +156,7 @@ uhd_error uhd_rx_streamer_last_error(
     char* error_out,
     size_t strbuffer_len
 ){
-    UHD_SAFE_C_SAVE_ERROR(h,
+    UHD_SAFE_C(
         memset(error_out, '\0', strbuffer_len);
         strncpy(error_out, h->last_error.c_str(), strbuffer_len);
     )


### PR DESCRIPTION
`uhd_tx_streamer_last_error` and `uhd_usrp_last_error` use
`UHD_SAFE_C` and so `uhd_rx_streamer_last_error` should as well
in order to be consistent.