### PR TITLE
Modify benchmark_rate.cpp to count rx sequence errors

### DIFF
--- a/host/examples/benchmark_rate.cpp
+++ b/host/examples/benchmark_rate.cpp
@@ -115,8 +115,11 @@ void benchmark_rx_rate(
             last_time = md.time_spec;
             had_an_overflow = true;
             // check out_of_sequence flag to see if it was a sequence error or overflow
-            if (!md.out_of_sequence)
+            if (md.out_of_sequence) {
+                num_seq_errors++;
+            } else {
                 num_overflows++;
+            }
             break;
 
         case uhd::rx_metadata_t::ERROR_CODE_LATE_COMMAND:


### PR DESCRIPTION
If ERROR_CODE_OVERFLOW occurred on rx, previously, we would only update
num_overflows when there was not a sequence error.

This change increments the number of sequence errors when there is a
sequence error and increments the number of overflows when there is
not a sequence error.