### PR TITLE
Python API: Fixed CMake's Python executable finding logic

### DIFF
--- a/host/cmake/Modules/UHDPython.cmake
+++ b/host/cmake/Modules/UHDPython.cmake
@@ -32,11 +32,20 @@ IF(PYTHON_EXECUTABLE)
 ELSE(PYTHON_EXECUTABLE)
 
     #use the built-in find script
-    FIND_PACKAGE(PythonInterp)
+    IF(ENABLE_PYTHON3)
+        FIND_PACKAGE(PythonInterp 3.0)
+    ELSE(ENABLE_PYTHON3)
+        FIND_PACKAGE(PythonInterp 2.0)
+    ENDIF(ENABLE_PYTHON3)
 
     #and if that fails use the find program routine
     IF(NOT PYTHONINTERP_FOUND)
-        FIND_PROGRAM(PYTHON_EXECUTABLE NAMES python python2.7 python2.6)
+        IF(ENABLE_PYTHON3)
+            FIND_PROGRAM(PYTHON_EXECUTABLE NAMES python3 python 3.6)
+        ELSE(ENABLE_PYTHON3)
+            FIND_PROGRAM(PYTHON_EXECUTABLE NAMES python2 python2.7 python2.6)
+        ENDIF(ENABLE_PYTHON3)
+
         IF(PYTHON_EXECUTABLE)
             SET(PYTHONINTERP_FOUND TRUE)
         ENDIF(PYTHON_EXECUTABLE)


### PR DESCRIPTION
This fixes https://github.com/EttusResearch/uhd/issues/111.

I was able to reproduce the bug by replacing `/usr/bin/python` (which previously was a symlink to `python3` for me) with a symlink to `python2`. To me it looks like `UHDPython.cmake` doesn't care about `ENABLE_PYTHON3` when finding the executable. This pull request should fix this behavior.