### PR TITLE
Rfnoc radio channel map

### DIFF
--- a/host/include/uhd/rfnoc/radio_ctrl.hpp
+++ b/host/include/uhd/rfnoc/radio_ctrl.hpp
@@ -219,6 +219,20 @@ public:
      */
     virtual std::vector<std::string> get_gpio_banks() const = 0;
 
+    /*! Set the radio RX port->channel mapping
+     *
+     * \param port
+     * \param chan RX radio channel to associate with specified port
+     */
+    virtual void set_rx_port_chan_map(const size_t port, const size_t chan) = 0;
+
+    /*! Set the radio TX port->channel mapping
+     *
+     * \param port
+     * \param chan TX radio channel to associate with specified port
+     */
+    virtual void set_tx_port_chan_map(const size_t port, const size_t chan) = 0;
+
     /*!
      * Set a GPIO attribute on a particular GPIO bank.
      * Possible attribute names:

--- a/host/lib/rfnoc/graph_impl.cpp
+++ b/host/lib/rfnoc/graph_impl.cpp
@@ -68,26 +68,28 @@ void graph_impl::connect(
             boost::dynamic_pointer_cast<uhd::rfnoc::node_ctrl_base>(dst),
             src_block_port
     );
-    if (src_block_port == uhd::rfnoc::ANY_PORT) {
-        src_block_port = actual_src_block_port;
-    } else if (src_block_port != actual_src_block_port) {
-        throw uhd::runtime_error(str(
-            boost::format("Can't connect to port %d on block %s.")
-            % src_block_port % src->unique_id()
-        ));
-    }
+    src_block_port = actual_src_block_port;
+    // if (src_block_port == uhd::rfnoc::ANY_PORT) {
+    //     src_block_port = actual_src_block_port;
+    // } else if (src_block_port != actual_src_block_port) {
+    //     throw uhd::runtime_error(str(
+    //         boost::format("Can't connect to port %d on block %s.")
+    //         % src_block_port % src->unique_id()
+    //     ));
+    // }
     size_t actual_dst_block_port = dst->connect_upstream(
             boost::dynamic_pointer_cast<uhd::rfnoc::node_ctrl_base>(src),
             dst_block_port
     );
-    if (dst_block_port == uhd::rfnoc::ANY_PORT) {
-        dst_block_port = actual_dst_block_port;
-    } else if (dst_block_port != actual_dst_block_port) {
-        throw uhd::runtime_error(str(
-            boost::format("Can't connect to port %d on block %s.")
-            % dst_block_port % dst->unique_id()
-        ));
-    }
+    dst_block_port = actual_dst_block_port;
+    // if (dst_block_port == uhd::rfnoc::ANY_PORT) {
+    //     dst_block_port = actual_dst_block_port;
+    // } else if (dst_block_port != actual_dst_block_port) {
+    //     throw uhd::runtime_error(str(
+    //         boost::format("Can't connect to port %d on block %s.")
+    //         % dst_block_port % dst->unique_id()
+    //     ));
+    // }
     src->set_downstream_port(actual_src_block_port, actual_dst_block_port);
     dst->set_upstream_port(actual_dst_block_port, actual_src_block_port);
     // At this point, ports are locked and no one else can simply connect

--- a/host/lib/rfnoc/radio_ctrl_impl.hpp
+++ b/host/lib/rfnoc/radio_ctrl_impl.hpp
@@ -105,6 +105,9 @@ public:
     );
     virtual uint32_t get_gpio_attr(const std::string &bank, const std::string &attr);
 
+    virtual void set_tx_port_chan_map(const size_t port, const size_t chan);
+    virtual void set_rx_port_chan_map(const size_t port, const size_t chan);
+
     /***********************************************************************
      * Block control API calls
      **********************************************************************/
@@ -123,6 +126,23 @@ public:
 
 protected: // TODO see what's protected and what's private
     void _register_loopback_self_test(size_t chan);
+
+    /*! Override _request_output_port to return the
+     *  specified RX port->chan map
+     */
+    virtual size_t _request_output_port(
+            const size_t suggested_port,
+            const uhd::device_addr_t &args
+    ) const;
+
+    /*! Override _request_input_port to return the
+     *  specified TX port->chan map
+     */
+    virtual size_t _request_input_port(
+            const size_t suggested_port,
+            const uhd::device_addr_t &args
+    ) const;
+
 
     /***********************************************************************
      * Registers
@@ -223,6 +243,8 @@ private:
 
     // Cached values
     double _tick_rate;
+    std::map<size_t, size_t> _tx_port_chan_map;
+    std::map<size_t, size_t> _rx_port_chan_map;
     std::map<size_t, std::string> _tx_antenna;
     std::map<size_t, std::string> _rx_antenna;
     std::map<size_t, double> _tx_freq;


### PR DESCRIPTION
This PR adds a mapping between port and channels in the radio_ctrl in order to perform single-channel collections on channel 1. 

As currently implemented, there's serious problems when trying to select channel 1 instead of channel 0 in a single-channel collection. When issueing a stream command, the stream command port selection must match across all downstream rfnoc blocks, yet the RF receive/transmit channel is inherently tied to the block port selected in software. So, if we wanted to do a single-channel collection on channel 1, there's not really a feasible way to bring this data into an rfnoc flow graph with multiple connected blocks across different block port indices. Even using legacy mode, a single channel RX collection is possible only with a 2-channel DDC, because the receive block port index 1 must match the DDC block port index 1. 

This PR attempts to decouple the hardware RF channel from the software block port inside the radio_ctrl. This is done by:
1. Adding a map inside radio_ctrl_impl to translate from port to hardware channel. These maps default to the port index, so it should not impact behavior by default
2. Adding hooks to set the port/channel mapping
3. Overriding _request_output_port and _request_input_port of source_node_ctrl and sink_node_ctrl, respectively, to return the port that corresponds with the hardware receive channel when requested.

Additionally, I needed to disable a check in graph_impl in order for Step 3 to work successfully. Since the connecting block requests port 0, but the radio block might return port 1 (for example), the check that `dst_block_port != actual_dst_block_port` would throw an error. When disabled, the port mapping functionality works. Is this a required check? Any better way to get around this feature where the radio_ctrl might return a different port than requested?