### PR TITLE
Unbreak build against Boost 1.67

### DIFF
--- a/host/examples/rx_samples_to_file.cpp
+++ b/host/examples/rx_samples_to_file.cpp
@@ -162,7 +162,7 @@ template<typename samp_type> void recv_to_file(
 
 typedef boost::function<uhd::sensor_value_t (const std::string&)> get_sensor_fn_t;
 
-bool check_locked_sensor(std::vector<std::string> sensor_names, const char* sensor_name, get_sensor_fn_t get_sensor_fn, double setup_time){
+bool check_locked_sensor(std::vector<std::string> sensor_names, const char* sensor_name, get_sensor_fn_t get_sensor_fn, long setup_time){
     if (std::find(sensor_names.begin(), sensor_names.end(), sensor_name) == sensor_names.end())
         return false;
 
@@ -207,7 +207,8 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     //variables to be set by po
     std::string args, file, type, ant, subdev, ref, wirefmt, channel;
     size_t total_num_samps, spb;
-    double rate, freq, gain, bw, total_time, setup_time;
+    double rate, freq, gain, bw, total_time;
+    long setup_time;
 
     //setup the program options
     po::options_description desc("Allowed options");
@@ -229,7 +230,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
         ("bw", po::value<double>(&bw), "analog frontend filter bandwidth in Hz")
         ("ref", po::value<std::string>(&ref)->default_value("internal"), "reference source (internal, external, mimo)")
         ("wirefmt", po::value<std::string>(&wirefmt)->default_value("sc16"), "wire format (sc8, sc16 or s16)")
-        ("setup", po::value<double>(&setup_time)->default_value(1.0), "seconds of setup time")
+        ("setup", po::value<long>(&setup_time)->default_value(1), "seconds of setup time")
         ("progress", "periodically display short-term bandwidth")
         ("stats", "show average bandwidth on exit")
         ("sizemap", "track packet size and display breakdown on exit")
@@ -310,7 +311,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     if (vm.count("ant")) usrp->set_rx_antenna(ant);
 
     std::this_thread::sleep_for(
-        std::chrono::milliseconds(int64_t(1000 * setup_time))
+        std::chrono::seconds(setup_time)
     );
 
     //check Ref and LO Lock detect

--- a/host/examples/tx_samples_from_file.cpp
+++ b/host/examples/tx_samples_from_file.cpp
@@ -57,7 +57,8 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     //variables to be set by po
     std::string args, file, type, ant, subdev, ref, wirefmt, channel;
     size_t spb;
-    double rate, freq, gain, bw, delay, lo_off;
+    double rate, freq, gain, bw, lo_off;
+    long delay;
 
     //setup the program options
     po::options_description desc("Allowed options");
@@ -76,7 +77,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
         ("bw", po::value<double>(&bw), "analog frontend filter bandwidth in Hz")
         ("ref", po::value<std::string>(&ref)->default_value("internal"), "reference source (internal, external, mimo)")
         ("wirefmt", po::value<std::string>(&wirefmt)->default_value("sc16"), "wire format (sc8 or sc16)")
-        ("delay", po::value<double>(&delay)->default_value(0.0), "specify a delay between repeated transmission of file (in seconds)")
+        ("delay", po::value<long>(&delay)->default_value(0), "specify a delay between repeated transmission of file (in seconds)")
         ("channel", po::value<std::string>(&channel)->default_value("0"), "which channel to use")
         ("repeat", "repeatedly transmit file")
         ("int-n", "tune USRP with integer-n tuning")
@@ -196,10 +197,10 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
         else if (type == "short") send_from_file<std::complex<short> >(tx_stream, file, spb);
         else throw std::runtime_error("Unknown type " + type);
 
-        if(repeat and delay > 0.0) {
+        if(repeat and delay > 0) {
             boost::this_thread::sleep(boost::posix_time::milliseconds(delay));
             std::this_thread::sleep_for(
-                std::chrono::milliseconds(int64_t(delay*1000))
+                std::chrono::seconds(delay)
             );
         }
     } while(repeat and not stop_signal_called);

--- a/host/lib/transport/nirio/niusrprio_session.cpp
+++ b/host/lib/transport/nirio/niusrprio_session.cpp
@@ -207,7 +207,7 @@ nirio_status niusrprio_session::_ensure_fpga_ready()
         //there is a small chance that the server is still finishing up cleaning up
         //the DMA FIFOs. We currently don't have any feedback from the driver regarding
         //this state so just wait.
-        boost::this_thread::sleep(boost::posix_time::milliseconds(FPGA_READY_TIMEOUT_IN_MS));
+        boost::this_thread::sleep(boost::posix_time::milliseconds(long(FPGA_READY_TIMEOUT_IN_MS)));
 
         //Disable all FIFOs in the FPGA
         for (size_t i = 0; i < _lvbitx->get_input_fifo_count(); i++) {

--- a/host/lib/transport/nirio/rpc/usrprio_rpc_client.cpp
+++ b/host/lib/transport/nirio/rpc/usrprio_rpc_client.cpp
@@ -14,7 +14,7 @@ usrprio_rpc_client::usrprio_rpc_client(
     std::string server,
     std::string port
 ) : _rpc_client(server, port, uhd::get_process_id(), uhd::get_host_id()),
-    _timeout(boost::posix_time::milliseconds(DEFAULT_TIMEOUT_IN_MS))
+    _timeout(boost::posix_time::milliseconds(long(DEFAULT_TIMEOUT_IN_MS)))
 {
    _ctor_status = _rpc_client.status() ? NiRio_Status_RpcConnectionError : NiRio_Status_Success;
 }

--- a/host/lib/usrp/cores/rx_vita_core_3000.cpp
+++ b/host/lib/usrp/cores/rx_vita_core_3000.cpp
@@ -64,7 +64,7 @@ struct rx_vita_core_3000_impl : rx_vita_core_3000
         // At 1 ms * 200 MHz = 200k cycles, 8 bytes * 200k cycles = 1.6 MB
         // of flushed data, when the typical amount of data buffered
         // is on the order of kilobytes
-        boost::this_thread::sleep(boost::posix_time::milliseconds(1.0));
+        boost::this_thread::sleep(boost::posix_time::milliseconds(1));
 
         _iface->poke32(REG_FC_WINDOW, window_size-1);
         _iface->poke32(REG_FC_ENABLE, window_size?1:0);

--- a/host/lib/usrp/gps_ctrl.cpp
+++ b/host/lib/usrp/gps_ctrl.cpp
@@ -296,19 +296,19 @@ private:
     //issue some setup stuff so it spits out the appropriate data
     //none of these should issue replies so we don't bother looking for them
     //we have to sleep between commands because the JL device, despite not acking, takes considerable time to process each command.
-     sleep(milliseconds(GPSDO_COMMAND_DELAY_MS));
+     sleep(milliseconds(long(GPSDO_COMMAND_DELAY_MS)));
     _send("SYST:COMM:SER:ECHO OFF\r\n");
-     sleep(milliseconds(GPSDO_COMMAND_DELAY_MS));
+     sleep(milliseconds(long(GPSDO_COMMAND_DELAY_MS)));
     _send("SYST:COMM:SER:PRO OFF\r\n");
-     sleep(milliseconds(GPSDO_COMMAND_DELAY_MS));
+     sleep(milliseconds(long(GPSDO_COMMAND_DELAY_MS)));
     _send("GPS:GPGGA 1\r\n");
-     sleep(milliseconds(GPSDO_COMMAND_DELAY_MS));
+     sleep(milliseconds(long(GPSDO_COMMAND_DELAY_MS)));
     _send("GPS:GGAST 0\r\n");
-     sleep(milliseconds(GPSDO_COMMAND_DELAY_MS));
+     sleep(milliseconds(long(GPSDO_COMMAND_DELAY_MS)));
     _send("GPS:GPRMC 1\r\n");
-     sleep(milliseconds(GPSDO_COMMAND_DELAY_MS));
+     sleep(milliseconds(long(GPSDO_COMMAND_DELAY_MS)));
     _send("SERV:TRAC 1\r\n");
-     sleep(milliseconds(GPSDO_COMMAND_DELAY_MS));
+     sleep(milliseconds(long(GPSDO_COMMAND_DELAY_MS)));
   }
 
   //helper function to retrieve a field from an NMEA sentence

--- a/host/lib/usrp/x300/x300_impl.cpp
+++ b/host/lib/usrp/x300/x300_impl.cpp
@@ -1530,7 +1530,7 @@ void x300_impl::sync_times(mboard_members_t &mb, const uhd::time_spec_t& t)
 
 bool x300_impl::wait_for_clk_locked(mboard_members_t& mb, uint32_t which, double timeout)
 {
-    boost::system_time timeout_time = boost::get_system_time() + boost::posix_time::milliseconds(timeout * 1000.0);
+    boost::system_time timeout_time = boost::get_system_time() + boost::posix_time::milliseconds(long(timeout * 1000));
     do {
         if (mb.fw_regmap->clock_status_reg.read(which)==1)
             return true;


### PR DESCRIPTION
Regressed by boostorg/date_time@f9f2aaf5216c. Found [downstream](https://reviews.freebsd.org/D15030) ([error log](http://package22.nyi.freebsd.org/data/111amd64-default-PR227427/2018-04-14_08h49m03s/logs/errors/uhd-3.10.3.0_2.log)).
UHD < 3.11 (e.g., `release_003_010_003_000` tag) also need 305d0e79e219:
https://github.com/EttusResearch/uhd/blob/ef1576780bc927b8611640091b15f3d051cb97ad/host/examples/benchmark_rate.cpp#L34
https://github.com/EttusResearch/uhd/blob/ef1576780bc927b8611640091b15f3d051cb97ad/host/examples/benchmark_rate.cpp#L474
