### PR TITLE
boost: Fixed boost posix_time compilation issue for boost 1.67

### DIFF
--- a/host/examples/benchmark_rate.cpp
+++ b/host/examples/benchmark_rate.cpp
@@ -364,7 +364,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
         if(ref != "internal") {
             std::cout << "Now confirming lock on clock signals..." << std::endl;
             bool is_locked = false;
-            boost::system_time end_time = boost::get_system_time() + boost::posix_time::milliseconds(CLOCK_TIMEOUT);
+            boost::system_time end_time = boost::get_system_time() + boost::posix_time::milliseconds(int64_t(CLOCK_TIMEOUT));
             for (int i = 0; i < num_mboards; i++) {
                 if (ref == "mimo" and i == 0) continue;
                 while((is_locked = usrp->get_mboard_sensor("ref_locked",i).to_bool()) == false and
@@ -471,7 +471,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     const long usecs = long((duration - secs)*1e6);
     boost::this_thread::sleep(boost::posix_time::seconds(secs)
             + boost::posix_time::microseconds(usecs)
-            + boost::posix_time::milliseconds( (rx_channel_nums.size() <= 1 and tx_channel_nums.size() <= 1) ? 0 : (INIT_DELAY * 1000))
+            + boost::posix_time::milliseconds(int64_t((rx_channel_nums.size() <= 1 and tx_channel_nums.size() <= 1) ? 0 : (INIT_DELAY * 1000)))
     );
 
     //interrupt and join the threads

--- a/host/examples/rx_samples_to_file.cpp
+++ b/host/examples/rx_samples_to_file.cpp
@@ -182,7 +182,7 @@ bool check_locked_sensor(std::vector<std::string> sensor_names, const char* sens
 
     while (true) {
         if ((not first_lock_time.is_not_a_date_time()) and
-                (boost::get_system_time() > (first_lock_time + boost::posix_time::seconds(setup_time))))
+                (boost::get_system_time() > (first_lock_time + boost::posix_time::seconds(int64_t(setup_time)))))
         {
             std::cout << " locked." << std::endl;
             break;
@@ -196,7 +196,7 @@ bool check_locked_sensor(std::vector<std::string> sensor_names, const char* sens
         else {
             first_lock_time = boost::system_time();	//reset to 'not a date time'
 
-            if (boost::get_system_time() > (start + boost::posix_time::seconds(setup_time))){
+            if (boost::get_system_time() > (start + boost::posix_time::seconds(int64_t(setup_time)))){
                 std::cout << std::endl;
                 throw std::runtime_error(str(boost::format("timed out waiting for consecutive locks on sensor \"%s\"") % sensor_name));
             }
@@ -317,7 +317,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     //set the antenna
     if (vm.count("ant")) usrp->set_rx_antenna(ant);
 
-    boost::this_thread::sleep(boost::posix_time::seconds(setup_time)); //allow for some setup time
+    boost::this_thread::sleep(boost::posix_time::seconds(int64_t(setup_time))); //allow for some setup time
 
     //check Ref and LO Lock detect
     if (not vm.count("skip-lo")){

--- a/host/examples/tx_samples_from_file.cpp
+++ b/host/examples/tx_samples_from_file.cpp
@@ -199,7 +199,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
         else if (type == "short") send_from_file<std::complex<short> >(tx_stream, file, spb);
         else throw std::runtime_error("Unknown type " + type);
 
-        if(repeat and delay != 0.0) boost::this_thread::sleep(boost::posix_time::milliseconds(delay));
+        if(repeat and delay != 0.0) boost::this_thread::sleep(boost::posix_time::milliseconds(int64_t(delay)));
     } while(repeat and not stop_signal_called);
 
     //finished

--- a/host/lib/usrp/x300/x300_impl.cpp
+++ b/host/lib/usrp/x300/x300_impl.cpp
@@ -1486,7 +1486,7 @@ void x300_impl::sync_times(mboard_members_t &mb, const uhd::time_spec_t& t)
 
 bool x300_impl::wait_for_clk_locked(mboard_members_t& mb, boost::uint32_t which, double timeout)
 {
-    boost::system_time timeout_time = boost::get_system_time() + boost::posix_time::milliseconds(timeout * 1000.0);
+    boost::system_time timeout_time = boost::get_system_time() + boost::posix_time::milliseconds(int64_t(timeout * 1000));
     do {
         if (mb.fw_regmap->clock_status_reg.read(which)==1)
             return true;


### PR DESCRIPTION
This PR addresses an issue I was having with the LTS version of UHD and the latest boost version 1.67, and to let you all know about it. I saw multiple errors like this:

`x300_impl.cpp:1489:114: error: no matching function for call to ‘boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000>::subsecond_duration(double)’`

I did not have this issue with the master branch. Seems to be fixed there.
