### PR TITLE
GPGGA Sentence NaN Bugfixes (E310)

### DIFF
--- a/host/lib/usrp/gpsd_iface.cpp
+++ b/host/lib/usrp/gpsd_iface.cpp
@@ -242,9 +242,9 @@ private: // member functions
             % tm.tm_hour
             % tm.tm_min
             % tm.tm_sec
-            % _deg_to_dm(std::fabs(_gps_data.fix.latitude))
+            % _zeroize(_deg_to_dm(std::fabs(_gps_data.fix.latitude)))
             % ((_gps_data.fix.latitude > 0) ? 'N' : 'S')
-            % _deg_to_dm(std::fabs(_gps_data.fix.longitude))
+            % _zeroize(_deg_to_dm(std::fabs(_gps_data.fix.longitude)))
             % ((_gps_data.fix.longitude > 0) ? 'E' : 'W')
             % _gps_data.status
             % _gps_data.satellites_used);
@@ -256,13 +256,13 @@ private: // member functions
                 str(boost::format("%.2f,") % _gps_data.dop.hdop));
 
         if (boost::math::isnan(_gps_data.fix.altitude))
-            string.append(",");
+            string.append(",,");
         else
             string.append(
                 str(boost::format("%.2f,M,") % _gps_data.fix.altitude));
 
         if (boost::math::isnan(_gps_data.separation))
-            string.append(",");
+            string.append(",,");
         else
             string.append(
                 str(boost::format("%.3f,M,") % _gps_data.separation));


### PR DESCRIPTION
Occasionally, the E310 GPSD driver will return NaN values for fields used in the construction of the GPGGA sentences.  This pull request zeros out the lat/lon fields if NaN values are encountered (similarly to GPRMC) and preserves the number of commas in the output sentence if altitude or geoidal separation are NaN as well.