### PR TITLE
cores:rx_frontend_core_3000: fix real mode

### DIFF
--- a/host/lib/usrp/cores/rx_frontend_core_3000.cpp
+++ b/host/lib/usrp/cores/rx_frontend_core_3000.cpp
@@ -82,6 +82,8 @@ public:
         uint32_t mapping_reg_val = 0;
         switch (fe_conn.get_sampling_mode()) {
         case fe_connection_t::REAL:
+            mapping_reg_val = FLAG_DSP_RX_MAPPING_REAL_MODE;
+            break;
         case fe_connection_t::HETERODYNE:
             mapping_reg_val = FLAG_DSP_RX_MAPPING_REAL_MODE|FLAG_DSP_RX_MAPPING_REAL_DECIM;
             break;


### PR DESCRIPTION
Since 3.12, real mode with basicRx present issues : 
- sample rate is divided by 2;
- no synchronization between channel.
This is due to the same configuration in host/lib/usrp/cores/rx_frontend_core_3000.cpp for real and heterodyne mode where real_decim is always enabled.
This patch add differentiate behaviour for simple real mode and heterodyne mode.

Gwenhael
