### PR TITLE
Fixed get_tx_stream reference

### DIFF
--- a/host/include/uhd/usrp/multi_usrp.hpp
+++ b/host/include/uhd/usrp/multi_usrp.hpp
@@ -144,7 +144,7 @@ public:
     //! Convenience method to get a RX streamer. See also uhd::device::get_rx_stream().
     virtual rx_streamer::sptr get_rx_stream(const stream_args_t &args) = 0;
 
-    //! Convenience method to get a TX streamer. See also uhd::device::get_rx_stream().
+    //! Convenience method to get a TX streamer. See also uhd::device::get_tx_stream().
     virtual tx_streamer::sptr get_tx_stream(const stream_args_t &args) = 0;
 
     /*!


### PR DESCRIPTION
I was trying to figure out how to destroy a streamer in order to create a new one and came across what I believe is a copy-paste error in the documentation.  