### PR TITLE
Yet another boost >= 1.67 fix

### DIFF
--- a/host/lib/usrp/e300/e300_fifo_config.cpp
+++ b/host/lib/usrp/e300/e300_fifo_config.cpp
@@ -108,7 +108,7 @@ struct e300_fifo_poll_waiter
         boost::mutex::scoped_lock l(_mutex);
         if (_poll_claimed)
         {
-            _cond.timed_wait(l, boost::posix_time::microseconds(timeout*1000000));
+            _cond.timed_wait(l, boost::posix_time::microseconds(long(timeout*1000000)));
         }
         else
         {


### PR DESCRIPTION
| host/lib/usrp/e300/e300_fifo_config.cpp:111:80: error: no matching function for call to 'boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000000>::subsecond_duration(double)'

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>