### PR TITLE
filter: Fix return value in get_rolloff

### DIFF
--- a/host/include/uhd/types/filters.hpp
+++ b/host/include/uhd/types/filters.hpp
@@ -125,7 +125,7 @@ namespace uhd{
 
         UHD_INLINE double get_rolloff()
         {
-            return _cutoff;
+            return _rolloff;
         }
 
         UHD_INLINE void set_cutoff(const double cutoff)


### PR DESCRIPTION
Fixes a simple copy-paste error in the Analog LP filter API.