### PR TITLE
streamer: expose Tx and Rx streamer update methods in public API

### DIFF
--- a/host/include/uhd/stream.hpp
+++ b/host/include/uhd/stream.hpp
@@ -236,6 +236,26 @@ public:
      * \param stream_cmd the stream command to issue
      */
     virtual void issue_stream_cmd(const stream_cmd_t &stream_cmd) = 0;
+
+    /*!
+     * Sets the tick rate on the streamer.
+     */
+    virtual void set_tick_rate(const double rate) = 0;
+
+    /*!
+     * Sets the sample rate on the streamer.
+     */
+    virtual void set_samp_rate(const double rate) = 0;
+
+    /*!
+     * Sets the scale factor on the streamer.
+     */
+    virtual void set_scale_factor(const double scale_factor) = 0;
+
+    /*!
+     * Flushes transport buffers of the streamer.
+     */
+    virtual void flush_all(const double timeout = 0.0) = 0;
 };
 
 /*!
@@ -295,6 +315,22 @@ public:
     virtual bool recv_async_msg(
         async_metadata_t &async_metadata, double timeout = 0.1
     ) = 0;
+
+    /*!
+     * Sets the tick rate on the streamer.
+     */
+    virtual void set_tick_rate(const double rate) = 0;
+
+    /*!
+     * Sets the sample rate on the streamer.
+     */
+    virtual void set_samp_rate(const double rate) = 0;
+
+    /*!
+     * Sets the scale factor on the streamer.
+     */
+    virtual void set_scale_factor(const double scale_factor) = 0;
+
 };
 
 } //namespace uhd

--- a/host/lib/transport/super_recv_packet_handler.hpp
+++ b/host/lib/transport/super_recv_packet_handler.hpp
@@ -857,6 +857,23 @@ public:
         return recv_packet_handler::issue_stream_cmd(stream_cmd);
     }
 
+    void set_tick_rate(const double rate){
+        return recv_packet_handler::set_tick_rate(rate);
+    }
+
+    void set_samp_rate(const double rate){
+        return recv_packet_handler::set_samp_rate(rate);
+    }
+
+    void set_scale_factor(const double scale_factor){
+        return recv_packet_handler::set_scale_factor(scale_factor);
+    }
+
+    void flush_all(const double timeout = 0.0)
+    {
+        return recv_packet_handler::flush_all(timeout);
+    }
+
 private:
     size_t _max_num_samps;
 };

--- a/host/lib/transport/super_send_packet_handler.hpp
+++ b/host/lib/transport/super_send_packet_handler.hpp
@@ -461,6 +461,18 @@ public:
         return send_packet_handler::recv_async_msg(async_metadata, timeout);
     }
 
+    void set_tick_rate(const double rate){
+        return send_packet_handler::set_tick_rate(rate);
+    }
+
+    void set_samp_rate(const double rate){
+        return send_packet_handler::set_samp_rate(rate);
+    }
+
+    void set_scale_factor(const double scale_factor){
+        return send_packet_handler::set_scale_factor(scale_factor);
+    }
+
 private:
     size_t _max_num_samps;
 };

--- a/host/lib/usrp/usrp1/io_impl.cpp
+++ b/host/lib/usrp/usrp1/io_impl.cpp
@@ -356,6 +356,22 @@ public:
         _stc->issue_stream_cmd(stream_cmd);
     }
 
+    void set_tick_rate(const double rate) {
+        return sph::recv_packet_handler::set_tick_rate(rate);
+    }
+
+    void set_samp_rate(const double rate) {
+        return sph::recv_packet_handler::set_samp_rate(rate);
+    }
+
+    void set_scale_factor(const double scale_factor) {
+        return sph::recv_packet_handler::set_scale_factor(scale_factor);
+    }
+
+    void flush_all(const double timeout) {
+        return sph::recv_packet_handler::flush_all(timeout);
+    }
+
 private:
     size_t _max_num_samps;
     soft_time_ctrl::sptr _stc;
@@ -414,6 +430,18 @@ public:
         async_metadata_t &async_metadata, double timeout = 0.1
     ){
         return _stc->get_async_queue().pop_with_timed_wait(async_metadata, timeout);
+    }
+
+    void set_tick_rate(const double rate) {
+        return sph::send_packet_handler::set_tick_rate(rate);
+    }
+
+    void set_samp_rate(const double rate) {
+        return sph::send_packet_handler::set_samp_rate(rate);
+    }
+
+    void set_scale_factor(const double scale_factor) {
+        return sph::send_packet_handler::set_scale_factor(scale_factor);
     }
 
 private:


### PR DESCRIPTION
This request exposes streamer methods that update the tick rate, sampling rate, and scale factor of Tx/Rx streamers. This enables the setup of streamers to RFNoC blocks without relying on the multi-usrp API.

For Tx streamer, this request brings out the following methods:
set_tick_rate
set_samp_rate
set_scale_factor

For Rx streamer, this request brings out the following methods:
set_tick_rate
set_samp_rate
set_scale_factor
flush_all

Note the API addition to usrp1/io_impl.cpp as well.