### PR TITLE
multi_usrp: fix get_{tx/rx}_dc_offset_range default argument

### DIFF
--- a/host/include/uhd/usrp/multi_usrp.hpp
+++ b/host/include/uhd/usrp/multi_usrp.hpp
@@ -1191,7 +1191,7 @@ public:
      * Get the valid range for RX DC offset values.
      * \param chan the channel index 0 to N-1
      */
-    virtual meta_range_t get_rx_dc_offset_range(size_t chan = ALL_CHANS) = 0;
+    virtual meta_range_t get_rx_dc_offset_range(size_t chan = 0) = 0;
 
     /*!
      * Enable/disable the automatic IQ imbalance correction.
@@ -1480,7 +1480,7 @@ public:
      * Get the valid range for TX DC offset values.
      * \param chan the channel index 0 to N-1
      */
-    virtual meta_range_t get_tx_dc_offset_range(size_t chan = ALL_CHANS) = 0;
+    virtual meta_range_t get_tx_dc_offset_range(size_t chan = 0) = 0;
 
     /*!
      * Set the TX frontend IQ imbalance correction.


### PR DESCRIPTION
# Pull Request Details
The use of the wildcard channel index, ALL_CHANS, as the default
value for the argument chan in the methods get_{tx/rx}_dc_offset_range
seems inappropriate. A default value of 0 is consistent with other
getters.

## Description
Changed default argument chan from ALL_CHANS to 0 for methods get_{tx/rx}_dc_offset_range.
Previous default value of ALL_CHANS causes a LookupError.

## Which devices/areas does this affect?
Any devices using the multi_usrp interface to query the TX/RX DC offset range.

## Testing Done
Tested with X310 and B205mini from C++/Python.  Tests cover use of multi_usrp interface
and extensive use of TX/RX streamer.

## Checklist
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [-] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes, and all previous tests pass.
