### PR TITLE
Kb1vc v3.14.0.0 a1 rpm fix

### DIFF
--- a/host/cmake/Modules/UHDPackage.cmake
+++ b/host/cmake/Modules/UHDPackage.cmake
@@ -177,7 +177,8 @@ configure_file(
 # Setup CPack RPM
 ########################################################################
 set(CPACK_RPM_PACKAGE_REQUIRES "boost-devel, python-requests")
-
+#set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/local;/usr/local/lib64;/usr/share/man;/usr/share/man/man1;/usr/lib64/pkgconfig;/usr/lib64/cmake;/usr/local/lib64/python2.7;/usr/local/lib64/python2.7/site-packages")
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/share/man;/usr/share/man/man1;/usr/lib64/pkgconfig;/usr/lib64/cmake;/usr/lib64/python2.7;/usr/lib64/python2.7/site-packages")
 foreach(filename post_install post_uninstall pre_install pre_uninstall)
     string(TOUPPER ${filename} filename_upper)
     list(APPEND CPACK_RPM_${filename_upper}_SCRIPT_FILE ${CMAKE_BINARY_DIR}/redhat/${filename})

--- a/host/cmake/redhat/post_install.in
+++ b/host/cmake/redhat/post_install.in
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-cp @CMAKE_INSTALL_PREFIX@/lib/uhd/utils/uhd-usrp.rules /etc/udev/rules.d/uhd-usrp.rules
+cp @CMAKE_INSTALL_PREFIX@/lib64/uhd/utils/uhd-usrp.rules /etc/udev/rules.d/uhd-usrp.rules
 udevadm control --reload-rules
 udevadm trigger
 ldconfig


### PR DESCRIPTION
# libuhd: Fix to RPM build scripts and cmake settings... 
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
The cmake script to prepare an RPM package for Fedora and other RedHat distros in 
commit d20a7ae29369fecf887f25489dd72dd377dcdd93 (tag: v3.14.0.0-a1-20181220)
for instance, is broken.  It produces an RPM that attempts to create directories in /usr
that get created by the filesystem package.  DNF, at least, resents this and will not install
the package cleanly.  

It is not obvious what the original script did wrong, but the cmake maintainers have apparently
seen this before, so there is a bit of cmake magic in the setting of CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION that makes the problem go away. 

That leaves us with a problem in the installation of the udev rules.  The original redhat/post_install.in
file referred to /usr/lib rather than /usr/lib64. 

Now the package builds and has worked on fresh Fedora 28 installs.  It has been tested against SoDaRadio as well. 

<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Affects: RPM installation, rpm based distributions
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing completed on raw Fedora 28 systems.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

