### PR TITLE
lib: experts: Include header for BOOST_VERSION

### DIFF
--- a/host/lib/include/uhdlib/experts/expert_nodes.hpp
+++ b/host/lib/include/uhdlib/experts/expert_nodes.hpp
@@ -12,6 +12,7 @@
 #include <uhd/exception.hpp>
 #include <uhd/utils/dirty_tracked.hpp>
 #include <uhd/types/time_spec.hpp>
+#include <boost/version.hpp>
 #if BOOST_VERSION >= 105600
 #include <boost/core/noncopyable.hpp>
 #endif


### PR DESCRIPTION
Otherwise the macro isn't defined and the condition is always false, and
the noncopyable.hpp header isn't included, so building with Boost 1.69
fails again.

Fixes f1d6d1e480ca ("lib: experts: fixup for including Boost header")

This change is required to build uhd in Fedora Rawhide with Boost 1.69.


- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes, and all previous tests pass.
