### PR TITLE
Expose useful functions of time_spec in Python API

### DIFF
--- a/host/lib/types/time_spec_python.hpp
+++ b/host/lib/types/time_spec_python.hpp
@@ -29,11 +29,13 @@ void export_time_spec(py::module& m)
         .def("get_real_secs"  , &time_spec_t::get_real_secs  )
         .def("get_frac_secs"  , &time_spec_t::get_frac_secs  )
 
-        .def(py::self += time_spec_t())
-        .def(py::self += double())
-        .def(py::self + double())
-        .def(py::self + time_spec_t())
-        .def(py::self -= time_spec_t())
+        .def(bp::self += time_spec_t())
+        .def(bp::self += double())
+        .def(bp::self + double())
+        .def(bp::self + time_spec_t())
+        .def(bp::self - double())
+        .def(bp::self - time_spec_t())
+        .def(bp::self -= time_spec_t())
         ;
 }
 

--- a/host/lib/types/time_spec_python.hpp
+++ b/host/lib/types/time_spec_python.hpp
@@ -27,6 +27,7 @@ void export_time_spec(py::module& m)
         .def("get_tick_count" , &time_spec_t::get_tick_count )
         .def("to_ticks"       , &time_spec_t::to_ticks       )
         .def("get_real_secs"  , &time_spec_t::get_real_secs  )
+        .def("get_full_secs"  , &time_spec_t::get_full_secs  )
         .def("get_frac_secs"  , &time_spec_t::get_frac_secs  )
 
         .def(bp::self += time_spec_t())


### PR DESCRIPTION
## Description
The PR exposes functions of time_spec that are generally useful and therefore 
probably should be accessible:
- minus operators for double and time_spec types,
- get_full_secs() function (get_frac_secs was exposed already).
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
None.

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->
None.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->


## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x ] I have read the CONTRIBUTING document.
- [ x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
