### PR TITLE
C: added uhd_get_abi_string, uhd_get_version_string

### DIFF
--- a/host/include/uhd.h
+++ b/host/include/uhd.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2015 Ettus Research LLC
- * Copyright 2018 Ettus Research, a National Instruments Company
+ * Copyright 2018-2019 Ettus Research, a National Instruments Company
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
@@ -10,6 +10,7 @@
 
 #include <uhd/config.h>
 #include <uhd/error.h>
+#include <uhd/version.h>
 
 #include <uhd/types/metadata.h>
 #include <uhd/types/ranges.h>

--- a/host/include/uhd/CMakeLists.txt
+++ b/host/include/uhd/CMakeLists.txt
@@ -44,6 +44,7 @@ if(ENABLE_C_API)
     UHD_INSTALL(FILES
         config.h
         error.h
+        version.h
         DESTINATION ${INCLUDE_DIR}/uhd
         COMPONENT headers
     )

--- a/host/include/uhd/version.h
+++ b/host/include/uhd/version.h
@@ -1,0 +1,35 @@
+//
+// Copyright 2019 Ettus Research, a National Instruments Company
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+#ifndef INCLUDED_UHD_VERSION_H
+#define INCLUDED_UHD_VERSION_H
+
+#include <uhd/config.h>
+#include <uhd/error.h>
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//! Get the ABI compatibility string for this build of the library
+UHD_API uhd_error uhd_get_abi_string(
+    char* abi_string_out,
+    size_t buffer_len
+);
+
+//! Get the version string (dotted version number + build info)
+UHD_API uhd_error uhd_get_version_string(
+    char* version_out,
+    size_t buffer_len
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INCLUDED_UHD_VERSION_H */

--- a/host/lib/CMakeLists.txt
+++ b/host/lib/CMakeLists.txt
@@ -131,6 +131,7 @@ LIBUHD_APPEND_SOURCES(
 if(ENABLE_C_API)
     LIBUHD_APPEND_SOURCES(
         ${CMAKE_CURRENT_SOURCE_DIR}/error_c.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/version_c.cpp
     )
 endif(ENABLE_C_API)
 

--- a/host/lib/version_c.cpp
+++ b/host/lib/version_c.cpp
@@ -1,0 +1,35 @@
+//
+// Copyright 2010-2012 Ettus Research LLC
+// Copyright 2018 Ettus Research, a National Instruments Company
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+#include <uhd/version.h>
+#include <uhd/version.hpp>
+
+#include <string.h>
+
+uhd_error uhd_get_abi_string(
+    char* abi_string_out,
+    size_t buffer_len
+){
+    UHD_SAFE_C(
+        const std::string cpp_abi_string = uhd::get_abi_string();
+
+        memset(abi_string_out, 0, buffer_len);
+        strncpy(abi_string_out, cpp_abi_string.c_str(), buffer_len);
+    )
+}
+
+uhd_error uhd_get_version_string(
+    char* version_out,
+    size_t buffer_len
+){
+    UHD_SAFE_C(
+        const std::string cpp_version = uhd::get_version_string();
+
+        memset(version_out, 0, buffer_len);
+        strncpy(version_out, cpp_version.c_str(), buffer_len);
+    )
+}


### PR DESCRIPTION
Clients that include the UHD C headers have access to the version and ABI #defines, but this is not available to clients that dynamically load the library. This commit adds publicly exported functions to provide this information.

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
See above.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
This is a usability improvement for C API clients. No specific devices are affected.
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I confirmed the output by printing.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
