### PR TITLE
rfnoc: Add update_graph() API call

### DIFF
--- a/host/lib/rfnoc/ddc_block_ctrl_impl.cpp
+++ b/host/lib/rfnoc/ddc_block_ctrl_impl.cpp
@@ -52,11 +52,12 @@ public:
                 .set_coercer([this, chan](const double value) {
                     return this->set_output_rate(value, chan);
                 })
-                .set(default_output_rate);
+                .set(default_output_rate)
+                .add_coerced_subscriber([this](const double) { update_graph(); });
             _tree->access<double>(get_arg_path("input_rate/value", chan))
-                .add_coerced_subscriber([this, chan](const double rate) {
-                    this->set_input_rate(rate, chan);
-                });
+                .add_coerced_subscriber(
+                    [this, chan](const double rate) { this->set_input_rate(rate, chan); })
+                .add_coerced_subscriber([this](const double) { update_graph(); });
 
             // Legacy properties (for backward compat w/ multi_usrp)
             const uhd::fs_path dsp_base_path = _root_path / "legacy_api" / chan;

--- a/host/lib/rfnoc/duc_block_ctrl_impl.cpp
+++ b/host/lib/rfnoc/duc_block_ctrl_impl.cpp
@@ -53,11 +53,13 @@ public:
                 .set_coercer([this, chan](const double value) {
                     return this->set_input_rate(value, chan);
                 })
-                .set(default_input_rate);
+                .set(default_input_rate)
+                .add_coerced_subscriber([this](const double) { update_graph(); });
             _tree->access<double>(get_arg_path("output_rate/value", chan))
                 .add_coerced_subscriber([this, chan](const double rate) {
                     this->set_output_rate(rate, chan);
-                });
+                })
+                .add_coerced_subscriber([this](const double) { update_graph(); });
 
             // Legacy properties (for backward compat w/ multi_usrp)
             const uhd::fs_path dsp_base_path = _root_path / "legacy_api" / chan;

--- a/host/lib/rfnoc/legacy_compat.cpp
+++ b/host/lib/rfnoc/legacy_compat.cpp
@@ -408,7 +408,7 @@ public:
         }
         // Update streamers:
         boost::dynamic_pointer_cast<uhd::usrp::device3_impl>(_device)
-            ->update_rx_streamers(rate);
+            ->update_rx_streamers();
     }
 
     void set_tx_rate(const double rate, const size_t chan)
@@ -460,7 +460,7 @@ public:
         }
         // Update streamers:
         boost::dynamic_pointer_cast<uhd::usrp::device3_impl>(_device)
-            ->update_tx_streamers(rate);
+            ->update_tx_streamers();
     }
 
 private: // types

--- a/host/lib/rfnoc/legacy_compat.cpp
+++ b/host/lib/rfnoc/legacy_compat.cpp
@@ -406,9 +406,6 @@ public:
                     .set(rate);
             }
         }
-        // Update streamers:
-        boost::dynamic_pointer_cast<uhd::usrp::device3_impl>(_device)
-            ->update_rx_streamers();
     }
 
     void set_tx_rate(const double rate, const size_t chan)
@@ -458,9 +455,6 @@ public:
                     .set(rate);
             }
         }
-        // Update streamers:
-        boost::dynamic_pointer_cast<uhd::usrp::device3_impl>(_device)
-            ->update_tx_streamers();
     }
 
 private: // types

--- a/host/lib/usrp/device3/device3_impl.cpp
+++ b/host/lib/usrp/device3/device3_impl.cpp
@@ -165,6 +165,11 @@ void device3_impl::enumerate_rfnoc_blocks(size_t device_index,
             boost::lock_guard<boost::mutex> lock(_block_ctrl_mutex);
             _rfnoc_block_ctrl.push_back(
                 uhd::rfnoc::block_ctrl_base::make(make_args, noc_id));
+            _rfnoc_block_ctrl.back()->set_graph_update_cb([this]() {
+                UHD_LOG_WARNING("DEVICE3", "Updating Streamers");
+                update_rx_streamers();
+                update_tx_streamers();
+            });
         }
     }
 }

--- a/host/lib/usrp/device3/device3_impl.hpp
+++ b/host/lib/usrp/device3/device3_impl.hpp
@@ -170,10 +170,15 @@ protected:
     /***********************************************************************
      * Streaming-related
      **********************************************************************/
-    // The 'rate' argument is so we can use these as subscribers to rate changes
 public: // TODO make these protected again
-    void update_rx_streamers(double rate = -1.0);
-    void update_tx_streamers(double rate = -1.0);
+    /*! Update tick rate, samp rate, and scaling on the streamers by querying
+     * the graph.
+     */
+    void update_rx_streamers();
+    /*! Update tick rate, samp rate, and scaling on the streamers by querying
+     * the graph.
+     */
+    void update_tx_streamers();
 
 protected:
     /***********************************************************************

--- a/host/lib/usrp/device3/device3_io_impl.cpp
+++ b/host/lib/usrp/device3/device3_io_impl.cpp
@@ -258,7 +258,7 @@ bool device3_impl::recv_async_msg(async_metadata_t& async_metadata, double timeo
 /***********************************************************************
  * Receive streamer
  **********************************************************************/
-void device3_impl::update_rx_streamers(double /* rate */)
+void device3_impl::update_rx_streamers()
 {
     for (const std::string& block_id : _rx_streamers.keys()) {
         UHD_RX_STREAMER_LOG() << "updating RX streamer to " << block_id;
@@ -523,7 +523,7 @@ rx_streamer::sptr device3_impl::get_rx_stream(const stream_args_t& args_)
 /***********************************************************************
  * Transmit streamer
  **********************************************************************/
-void device3_impl::update_tx_streamers(double /* rate */)
+void device3_impl::update_tx_streamers()
 {
     for (const std::string& block_id : _tx_streamers.keys()) {
         UHD_TX_STREAMER_LOG() << "updating TX streamer: " << block_id;

--- a/host/lib/usrp/x300/x300_impl.cpp
+++ b/host/lib/usrp/x300/x300_impl.cpp
@@ -1166,9 +1166,9 @@ void x300_impl::setup_mb(const size_t mb_i, const uhd::device_addr_t& dev_addr)
             return master_clock_rate;
         })
         .add_coerced_subscriber(
-            [this](const double rate) { this->update_tx_streamers(rate); })
+            [this](const double) { this->update_tx_streamers(); })
         .add_coerced_subscriber(
-            [this](const double rate) { this->update_rx_streamers(rate); })
+            [this](const double) { this->update_rx_streamers(); })
         .set(master_clock_rate);
 
     ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Pull Request Details
```
Author: Martin Braun <martin.braun@ettus.com>
Date:   Tue May 21 17:08:07 2019 -0700

    rfnoc: Add update_graph() API call

    Blocks that change scaling, tick rate, or sampling rate can now notify
    the graph to update streamers. Before, this was handled only by
    mult_usrp, and only for DDC and DUC blocks.

commit f90f57251672194b8fd48b40baf073ca8e78105d
Author: Martin Braun <martin.braun@ettus.com>
Date:   Tue May 21 16:20:43 2019 -0700

    device3: Remove unused 'rate' argument from update_?x_streamers()
```
## Description
In RFNoC graphs, the streamers need to know what the current sampling and tick rates are. When using multi_usrp, legacy_compat will update the streamers when the DDC or DUC rates are changed. However, when there is no multi_usrp, the streamers remain un-updated. This adds a callback that blocks can call when they updated the graph state. It will update the streamers.

## Related Issue
https://github.com/EttusResearch/uhd/pull/235

## Which devices/areas does this affect?
All proto-RFNoC devices.
