### PR TITLE
Fix linking of Python extension when loaded with statically-linked interpreter

### DIFF
--- a/host/python/CMakeLists.txt
+++ b/host/python/CMakeLists.txt
@@ -42,7 +42,16 @@ target_include_directories(pyuhd PUBLIC
     ${PYBIND11_INCLUDE_DIR}
 )
 
-target_link_libraries(pyuhd ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} uhd)
+if(WIN32)
+    target_link_libraries(pyuhd ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} uhd)
+else()
+    # for extension module, proper to NOT link against python library and instead
+    # add dynamic lookup link option on OSX
+    target_link_libraries(pyuhd ${Boost_LIBRARIES} uhd)
+    if(APPLE)
+        target_link_options(pyuhd PRIVATE "LINKER:-undefined,dynamic_lookup")
+    endif(APPLE)
+endif(WIN32)
 # Copy pyuhd library to the staging directory
 add_custom_command(TARGET pyuhd
     POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:pyuhd> ${CMAKE_CURRENT_BINARY_DIR}/uhd/$<TARGET_FILE_NAME:pyuhd>)

--- a/host/python/CMakeLists.txt
+++ b/host/python/CMakeLists.txt
@@ -34,7 +34,16 @@ add_library(pyuhd SHARED pyuhd.cpp)
 if(WIN32)
     set_target_properties(pyuhd PROPERTIES PREFIX "lib" SUFFIX ".pyd")
 else()
-    set_target_properties(pyuhd PROPERTIES PREFIX "lib" SUFFIX ".so")
+    execute_process(
+        COMMAND "${PYTHON_EXECUTABLE}" -c
+        "from distutils.sysconfig import get_config_var; print(get_config_var('EXT_SUFFIX'))"
+        OUTPUT_VARIABLE PYTHON_EXTENSION_SUFFIX
+    )
+    string(STRIP ${PYTHON_EXTENSION_SUFFIX} PYTHON_EXTENSION_SUFFIX)
+    if(${PYTHON_EXTENSION_SUFFIX} STREQUAL "None")
+        set(PYTHON_EXTENSION_SUFFIX ${CMAKE_SHARED_MODULE_SUFFIX})
+    endif()
+    set_target_properties(pyuhd PROPERTIES PREFIX "lib" SUFFIX ${PYTHON_EXTENSION_SUFFIX})
 endif(WIN32)
 target_include_directories(pyuhd PUBLIC
     ${PYTHON_NUMPY_INCLUDE_DIR}

--- a/host/python/CMakeLists.txt
+++ b/host/python/CMakeLists.txt
@@ -30,6 +30,12 @@ execute_process(
 
 # Build pyuhd library
 add_library(pyuhd SHARED pyuhd.cpp)
+# python expects extension modules with a particular suffix
+if(WIN32)
+    set_target_properties(pyuhd PROPERTIES PREFIX "lib" SUFFIX ".pyd")
+else()
+    set_target_properties(pyuhd PROPERTIES PREFIX "lib" SUFFIX ".so")
+endif(WIN32)
 target_include_directories(pyuhd PUBLIC
     ${PYTHON_NUMPY_INCLUDE_DIR}
     ${CMAKE_SOURCE_DIR}/lib
@@ -38,14 +44,8 @@ target_include_directories(pyuhd PUBLIC
 
 target_link_libraries(pyuhd ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} uhd)
 # Copy pyuhd library to the staging directory
-if(WIN32)
-    set(PYUHD_LIBRARY_NAME libpyuhd.pyd)
-else()
-    set(PYUHD_LIBRARY_NAME libpyuhd${CMAKE_SHARED_MODULE_SUFFIX})
-endif(WIN32)
-
 add_custom_command(TARGET pyuhd
-    POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:pyuhd> ${CMAKE_CURRENT_BINARY_DIR}/uhd/${PYUHD_LIBRARY_NAME})
+    POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:pyuhd> ${CMAKE_CURRENT_BINARY_DIR}/uhd/$<TARGET_FILE_NAME:pyuhd>)
 
 set(PYUHD_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
I ran across a couple issues when creating a uhd package for conda-forge (https://github.com/conda-forge/staged-recipes/pull/10076). First, since the binaries are relocated to the installation prefix from a different build environment, relative library paths are substituted and there was a problem on OSX where there was an internal reference to ``libpyuhd.dylib`` when ``libpyuhd.so`` was what the file was named. This is fixed by the first commit to use target properties to set the library filename instead of simply renaming the output file.

The second issue arose because conda uses a statically-linked Python, and builds on OSX were segfaulting when importing the Python extension module. The correct thing to do on Linux and OSX is to not link the ``libpyuhd`` extension module against the Python libraries and instead allow the interpreter to provide those symbols at runtime. This requires no further changes on Linux but does require setting a ``dynamic_lookup`` link option for OSX. These are done with the second commit. See the following for reference on linking Python extension modules:
https://bugs.python.org/issue21536
https://bugs.python.org/issue36721
https://blog.tim-smith.us/2015/09/python-extension-modules-os-x

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
These changes have been tested for building the above-mentioned uhd package for conda-forge, with the Python module now building and importing successfully on Linux, OSX, and Windows.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
