### PR TITLE
lib: utils: Don't use hard-coded path constants.

### DIFF
--- a/host/include/uhd/utils/paths.hpp
+++ b/host/include/uhd/utils/paths.hpp
@@ -23,6 +23,9 @@ UHD_API std::string get_tmp_path(void);
 //! Get a string representing the system's appdata directory
 UHD_API std::string get_app_path(void);
 
+//! Get a string representing the system's library directory
+UHD_API std::string get_lib_path(void);
+
 //! Get a string representing the system's pkg directory
 UHD_API std::string get_pkg_path(void);
 

--- a/host/lib/utils/paths.cpp
+++ b/host/lib/utils/paths.cpp
@@ -12,6 +12,10 @@
 
 #include <boost/algorithm/string.hpp>
 #include <functional>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106100
+#include <boost/dll/runtime_symbol_info.hpp>
+#endif
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <regex>
@@ -173,9 +177,27 @@ std::string uhd::get_app_path(void){
     return uhd::get_tmp_path();
 }
 
+#if BOOST_VERSION >= 106100
+std::string uhd::get_lib_path(void) {
+    fs::path runtime_libfile_path = boost::dll::this_line_location();
+    return runtime_libfile_path.remove_filename().string();
+}
+
+std::string uhd::get_pkg_path(void) {
+    fs::path pkg_path = fs::path(uhd::get_lib_path()).parent_path().lexically_normal();
+    return get_env_var("UHD_PKG_PATH", pkg_path.string());
+}
+#else
 std::string uhd::get_pkg_path(void) {
     return get_env_var("UHD_PKG_PATH", UHD_PKG_PATH);
 }
+
+std::string uhd::get_lib_path(void) {
+    fs::path lib_path = fs::path(uhd::get_pkg_path()) / UHD_LIB_DIR;
+    return lib_path.string();
+}
+#endif
+
 
 std::vector<fs::path> uhd::get_module_paths(void){
     std::vector<fs::path> paths;
@@ -185,7 +207,7 @@ std::vector<fs::path> uhd::get_module_paths(void){
         paths.push_back(str_path);
     }
 
-    paths.push_back(fs::path(uhd::get_pkg_path()) / UHD_LIB_DIR / "uhd" / "modules");
+    paths.push_back(fs::path(uhd::get_lib_path()) / "uhd" / "modules");
     paths.push_back(fs::path(uhd::get_pkg_path()) / "share" / "uhd" / "modules");
 
     return paths;
@@ -351,7 +373,7 @@ std::string uhd::find_image_path(const std::string &image_name, const std::strin
 }
 
 std::string uhd::find_utility(const std::string &name) {
-    return fs::path(fs::path(uhd::get_pkg_path()) / UHD_LIB_DIR / "uhd" / "utils" / name)
+    return fs::path(fs::path(uhd::get_lib_path()) / "uhd" / "utils" / name)
         .string();
 }
 


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This replaces the package path constant with a runtime library path lookup. The package path is taken to be the parent directory of the library directory.

Runtime path determination is preferable for making a relocatable library so that it is not necessary to do string substitution on relocated binaries (as with, for example, building a conda package https://github.com/conda-forge/staged-recipes/pull/10076). Conda does binary string replacement on Linux and OSX that makes this not strictly necessary on those platforms, but it does not do so on Windows. It's a relatively straightforward patch that I can maintain in the conda uhd package, but I thought it might be useful upstream.

One drawback is that this extends the use of Boost by including the header-only ``boost::dll::this_line_location``.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested build with the conda-forge uhd package and ``uhd_config_info`` outputs the correct paths.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
