### PR TITLE
Changes to eliminate compiler warnings in GCC v 9

### DIFF
--- a/host/include/uhd/rfnoc/registry.hpp
+++ b/host/include/uhd/rfnoc/registry.hpp
@@ -66,6 +66,9 @@ public:
      * \param device_id The 16-bit Device-ID for this block
      *        (ANY_DEVICE for device agnostic blocks).
      * \param block_name The name used for the block ID (e.g. "Radio").
+     * \param mb_access 
+     * \param timebase_clock
+     * \param ctrlport_clock
      * \param factory_fn A factory function that returns a reference to the
      *                   block.
      */

--- a/host/lib/deps/rpclib/include/rpc/msgpack/object.hpp
+++ b/host/lib/deps/rpclib/include/rpc/msgpack/object.hpp
@@ -610,7 +610,7 @@ inline object::object(const msgpack_object& o)
 inline void operator<< (clmdep_msgpack::object& o, const msgpack_object& v)
 {
     // FIXME beter way?
-    std::memcpy(&o, &v, sizeof(v));
+  std::memcpy((void *) &o, (void *) &v, sizeof(v));
 }
 
 inline object::operator msgpack_object() const

--- a/host/lib/rfnoc/mgmt_portal.cpp
+++ b/host/lib/rfnoc/mgmt_portal.cpp
@@ -250,6 +250,7 @@ public:
                 "initialize_endpoint(): Cannot reach node with specified address.");
         }
         const node_addr_t& node_addr = _node_addr_map.at(lookup_node);
+	(void) node_addr; // value may be unused if UHD_LOG_TRACE is disabled. 
         // Add/update the entry in the stream endpoint ID map
         _epid_addr_map[epid] = addr;
         UHD_LOG_DEBUG("RFNOC::MGMT",

--- a/host/lib/rfnoc/rfnoc_graph.cpp
+++ b/host/lib/rfnoc/rfnoc_graph.cpp
@@ -789,6 +789,7 @@ private:
         const size_t num_blocks,
         const size_t first_block_port)
     {
+        (void) mb_idx;
         UHD_LOG_TRACE(LOG_ID,
             std::string("Flushing and resetting blocks on mboard ")
                 + std::to_string(mb_idx));

--- a/host/lib/usrp/common/ad9361_driver/ad9361_device.cpp
+++ b/host/lib/usrp/common/ad9361_driver/ad9361_device.cpp
@@ -1838,7 +1838,7 @@ double ad9361_device_t::set_clock_rate(const double req_rate)
     /* Call into the clock configuration / settings function. This is where
      * all the hard work gets done. */
     double rate = _setup_rates(req_rate);
-
+    (void) rate; // supress unused warning if LOG trace is disabled.
     UHD_LOG_TRACE("AD936X", "[ad9361_device_t::set_clock_rate] rate=" << rate);
 
     /* Transition to the ALERT state and calibrate everything. */

--- a/host/lib/usrp/dboard/rhodium/rhodium_radio_control_cpld.cpp
+++ b/host/lib/usrp/dboard/rhodium/rhodium_radio_control_cpld.cpp
@@ -15,7 +15,12 @@ using namespace uhd::usrp;
 using namespace uhd::rfnoc;
 
 namespace {
-
+  // the following pragmas quiet the G++ "unsed function" warning.
+  // The warning indicates that this code is unused in some compilation
+  // configurations, and thus may be untested. 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+  
 const char* rx_band_to_log(rhodium_radio_control_impl::rx_band rx_band)
 {
     switch (rx_band) {
@@ -67,6 +72,7 @@ const char* tx_band_to_log(rhodium_radio_control_impl::tx_band tx_band)
             UHD_THROW_INVALID_CODE_PATH();
     }
 }
+#pragma GCC diagnostic pop
 } // namespace
 
 void rhodium_radio_control_impl::_update_rx_freq_switches(const double freq)

--- a/host/tests/client_zero_test.cpp
+++ b/host/tests/client_zero_test.cpp
@@ -93,7 +93,7 @@ public:
             last_flush_timeout = data;
             return;
         }
-        if ((addr & SLOT_OFFSET) == 1) {
+        if ((addr & SLOT_OFFSET) != 0) { // was == 1, but this is tautologically false, as SLOT_OFFSET = 512
             UHD_LOG_INFO("MOCK_REG_IFACE",
                 "Set flush/reset bits to flush=" << (data & 0x1) << ",ctrl_rst="
                                                  << ((data >> 1) & 0x1 >> 1)


### PR DESCRIPTION
# Description

Recent versions of gcc can actually generate bad code in the presence of behavior that triggers
what looks to be a warning. (This has been observed wrt a warning about a function returning a type T with no explicit return statement -- it caused a downstream segfault.)

All warnings were encountered with gcc 9.2.1

host/lib/deps/rpclib/include/rpc/msgpack/object.hpp
Compiler complains (and has complained for some time) about a blind
memcpy on two objects that may or may not be compatible. This behavior
is risky, but that's the way the implementers apparently wanted it.
So, the right way to do this is to cast the pointers to void and silence
the warning, though we wish one could do better.

host/lib/rfnoc/mgmt_portal.cpp
A variable "node_addr" was declared and initialized for later use in a
UHD_LOG_DEBUG statement.  As the existence of the call is conditioned on
configuration settings, when UHD_LOG_DEBUG is not expanded, the node_addr
value is unused.  The compiler complains.  Examination indicates that this
issue is benign. (Compilers warn of this because the condition may indicate
a possible mis-spelling that is syntactically irrelevant, but may be exposing
a value in an outer scope with a similar name.  Paranoid? Yup. Addresses a real
issue?  Yup.)
Providing an empty statement that treats node_addr as a void suffices to quiet
the warning, and is an acceptable and widely used pattern.

host/lib/rfnoc/rfnoc_graph.cpp
A function definition declares a parameter that is only used when UHD_LOG_TRACE
is expanded.  See above.  (void) mb_idx; fixes the problem.

host/lib/transport/libusb1_base.cpp
libusb folks changed the api to set debug level.  It once was libusb_set_debug
but now prefers lib_usb_set_option(.... )  The compiler complains that the
old libusb_set_debug routine is now deprecated.
This is now conditioned on LIBUSB_API_VERSION and wrapped in a UHD_USB_SET_DEBUG macro
in libuxb1_base.cpp

host/lib/usrp/common/ad9361_driver/ad9361_device.cpp
unused parameter "rate" only used when UHD_LOG_TRACE is expanded.  (void) rate satisfies
the compiler.

host/lib/usrp/dboard/rhodium/rhodium_radio_control_cpld.cpp
Compiler complains of unused functions "rx_band_to_log" and "tx_band_to_log".
The only real way to quiet the warning from gcc is with a pragma for GCC diagnostics.
As done here.

host/tests/client_zero_test.cpp
This is an interesting one: The original code was
        if ((addr & SLOT_OFFSET) == 1) {
But SLOT_OFFSET is 512.  This statement is *always* true.  I'm assuming that the
intent was to test to see that addr has the SLOT_OFFSET bit set.  Then:
        if ((addr & SLOT_OFFSET) != 0) {
is likely the answer.   This conditional triggers a call to UHD_LOG_INFO, so
it may not be covered by any test, and is unlikely to cause an operational issue.

## Affected devices

None, as these changes do not modify code behavior, but correct for possible spurious warnings 
that may mask other more important build-time messages. 


## Testing Done
Limited testing
1. Built on Fedora 30, gcc 9.2.1 
The warning that is left is related to missing descriptions in a Doxygen header, and a missing label. 
2. Ran "make test" for host/build only.  (All code modifications were within the host tree.)
3. Installed on Fedora 30, used to build SoDaRadio. Tested on B210. 


## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [ X] I have read the CONTRIBUTING document.
- [ X] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
