### PR TITLE
Update some CMakeLists.txt files to link against libtinfo

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -452,6 +452,7 @@ endforeach(Boost_Comp)
 if(ENABLE_USB)
     list(APPEND UHD_LINK_LIST_STATIC "usb-1.0")
 endif(ENABLE_USB)
+LIST(APPEND UHD_LINK_LIST_STATIC "tinfo")
 set(UHD_RFNOC_FOUND "TRUE")
 
 configure_file(

--- a/host/examples/CMakeLists.txt
+++ b/host/examples/CMakeLists.txt
@@ -55,11 +55,11 @@ find_package(Curses)
 if(CURSES_FOUND)
     include_directories(${CURSES_INCLUDE_DIR})
     add_executable(rx_ascii_art_dft rx_ascii_art_dft.cpp)
-    target_link_libraries(rx_ascii_art_dft uhd ${CURSES_LIBRARIES} ${Boost_LIBRARIES})
+    target_link_libraries(rx_ascii_art_dft uhd ${CURSES_LIBRARIES} tinfo ${Boost_LIBRARIES})
     UHD_INSTALL(TARGETS rx_ascii_art_dft RUNTIME DESTINATION ${PKG_LIB_DIR}/examples COMPONENT examples)
 
     add_executable(twinrx_freq_hopping twinrx_freq_hopping.cpp)
-    target_link_libraries(twinrx_freq_hopping uhd ${CURSES_LIBRARIES} ${Boost_LIBRARIES})
+    target_link_libraries(twinrx_freq_hopping uhd ${CURSES_LIBRARIES} tinfo ${Boost_LIBRARIES})
     UHD_INSTALL(TARGETS twinrx_freq_hopping RUNTIME DESTINATION ${PKG_LIB_DIR}/examples COMPONENT examples)
 endif(CURSES_FOUND)
 

--- a/host/utils/latency/CMakeLists.txt
+++ b/host/utils/latency/CMakeLists.txt
@@ -25,7 +25,7 @@ if(CURSES_FOUND)
         get_filename_component(name ${source} NAME_WE)
         add_executable(${name} ${source} ${latency_lib_path})
     	LIBUHD_APPEND_SOURCES(${name})
-        target_link_libraries(${name} uhd ${Boost_LIBRARIES} ${CURSES_LIBRARIES})
+	target_link_libraries(${name} uhd ${Boost_LIBRARIES} tinfo ${CURSES_LIBRARIES})
     	UHD_INSTALL(TARGETS ${name} RUNTIME DESTINATION ${latency_comp_dest} COMPONENT ${latency_comp_name})
     endforeach(source)
 


### PR DESCRIPTION
# Pull Request Details

## Description
This adds explicit linking to libtinfo for CMakeLists.txt that link against lcurses. Across distributions, it's not guaranteed which symbols are in libtinfo vs libncurses, which can cause linking problems. For example, on Gentoo linux compilation fails at the linking stage for the rx_ascii_art_dft example and latency utilities with errors like this:

```
/usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/rx_ascii_art_dft.dir/rx_ascii_art_dft.cpp.o: undefined reference to symbol 'stdscr'
/lib64/libtinfo.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
My proposed solution is to link against both ltinfo and lcurses. 

## Testing Done
I've compiled it on my own machine (gcc 6.4.0), and made sure the tests pass and the examples work. It should probably be tested by somebody who had no problems compiling previously to make sure that adding the tinfo link doesn't create new problems. 
 
## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly. (N/A)
- [ ] I have added tests to cover my changes, and all previous tests pass. (N/A?)