### PR TITLE
host/examples/ascii_art_dft.hpp: fix and modernize example main

### DIFF
--- a/host/examples/ascii_art_dft.hpp
+++ b/host/examples/ascii_art_dft.hpp
@@ -319,8 +319,12 @@ std::string dft_to_plot(const log_pwr_dft_type& dft_,
 #include <curses.h>
 #include <cstdlib>
 #include <iostream>
+#include <thread>
+#include <chrono>
 
 int main(void){
+    using namespace std::chrono_literals;
+
     initscr();
 
     while (true){
@@ -343,8 +347,9 @@ int main(void){
             12.5e4, 2.45e9,
             60, 0
         ).c_str());
+	refresh();
 
-        sleep(1);
+        std::this_thread::sleep_for(1s);
     }
 
 


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

The (commented-out) example main in [host/examples/ascii_art_dft.hpp](https://github.com/EttusResearch/uhd/blob/3b59529e71549976eaa99b75f40df732a8b73d6d/host/examples/ascii_art_dft.hpp#L315-L356) doesn't work out of the box. This patch fixes this with the following:

  - compilation error: ``sleep`` not defined (``#include <unistd.h>`` missing): use modern C++ ``std::this_thread::sleep_for`` instead of C-API ``sleep``;

  - functional error: no display: refresh screen after printing, as per ncurses [example](https://www.tldp.org/HOWTO/NCURSES-Programming-HOWTO/printw.html).

## Which devices/areas does this affect?

C++ host examples.

## Testing Done

No compiler warnings (``-Wall -Wextra``). Example works.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
