### PR TITLE
host: CMakeLists: add boost unit_test_framework required only when ENABLE_TESTS=ON

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -291,10 +291,14 @@ set(UHD_BOOST_REQUIRED_COMPONENTS
     filesystem
     program_options
     system
-    unit_test_framework
     serialization
     thread
 )
+
+if(ENABLE_TESTS)
+    list(APPEND UHD_BOOST_REQUIRED_COMPONENTS unit_test_framework)
+endif(ENABLE_TESTS)
+
 include(UHDBoost)
 
 include_directories(${Boost_INCLUDE_DIRS})


### PR DESCRIPTION

# Pull Request Details
## Description
By default, boost unit_test_framework is always required, but only use when ENABLE_TESTS=ON
This PR suppress unit_test_framework to the default list and append UHD_BOOST_REQUIRED_COMPONENTS when this library is needed

## Which devices/areas does this affect?
cmake

## Testing Done
Tested with a docker container:
- with all required library but no unit_test_framework and ENABLE_TESTS=OFF => pass
- with all required library (included unit_test_framework) ENABLE_TESTS=ON => pass
- with all required library but no unit_test_framework and ENABLE_TESTS=ON => displays error message (OK)

## Checklist
- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
