### PR TITLE
utils: Make uhd_config_info print help by default

### DIFF
--- a/host/utils/uhd_config_info.cpp
+++ b/host/utils/uhd_config_info.cpp
@@ -43,7 +43,7 @@ int UHD_SAFE_MAIN(int argc, char* argv[])
     po::notify(vm);
 
     // Print the help message
-    if (vm.count("help") > 0) {
+    if (vm.count("help") > 0 or vm.empty()) {
         std::cout << boost::format("UHD Config Info - %s") % desc << std::endl;
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
# Pull Request Details

## Description
`uhd_config_info` currently displays nothing if called without an argument. This change causes the help text to be displayed if no arguments are supplied.

## Related Issue
None

## Which devices/areas does this affect?
Only the default behavior of `uhd_config_info`

## Testing Done
Ran `uhd_config_info` without arguments and saw the help text displayed

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
