### PR TITLE
[ad9361_device] Correct mask for product ID check.

### DIFF
--- a/host/lib/usrp/common/ad9361_driver/ad9361_device.cpp
+++ b/host/lib/usrp/common/ad9361_driver/ad9361_device.cpp
@@ -1604,7 +1604,7 @@ void ad9361_device_t::initialize()
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     /* Check device ID to make sure iface works */
-    uint32_t device_id = (_io_iface->peek8(0x037) & 0x8);
+    uint32_t device_id = (_io_iface->peek8(0x037) & 0xf8);
     if (device_id != 0x8) {
         throw uhd::runtime_error(
             str(boost::format("[ad9361_device_t::initialize] Device ID readback failure. "


### PR DESCRIPTION
# Pull Request Details
Working on derivative products which use the AD9361, often times the driver would fail in very strange ways.  At one point, I noticed even a device in reset would pass the initial product ID readback.  Looking against the ADI no-OS code repository, it appears the product ID check should be masked with 0xF8 and checked to be 0x08.  With a device off and weak pull-ups, the readback would always read 0xFF, passing the ID check when it obviously wasn't there.  Extending the mask to be 0xF8 shows that both 0's and 1's are read back from the device.

## Description
Fixes an incorrect product ID read back which may indicate faulty hardware.  Devices being held in reset will currently pass this check.

## Related Issue
N/A

## Which devices/areas does this affect?
All devices with AD936x transceivers.

## Testing Done
N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [ x] I have read the CONTRIBUTING document.
- [ x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
