### PR TITLE
lib: utils: Fix runtime prefix determination through get_lib_path()

### DIFF
--- a/host/lib/utils/paths.cpp
+++ b/host/lib/utils/paths.cpp
@@ -293,7 +293,9 @@ std::string uhd::get_pkg_path(void)
 std::string uhd::get_lib_path(void)
 {
     fs::path runtime_libfile_path = boost::dll::this_line_location();
-    return runtime_libfile_path.remove_filename().string();
+    //Normalize before decomposing path so result is reliable
+    fs::path lib_path = runtime_libfile_path.lexically_normal().parent_path();
+    return lib_path.string();
 }
 #else
 std::string uhd::get_pkg_path(void)


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

get_lib_path() uses the libuhd location on disk to dynamically determine the installation prefix at runtime. This fix normalizes the libuhd path before any path operations are done to extract the library directory and then prefix directory.

Previously, using a non-normalized library path, the returned prefix directory would be incorrect in some cases (e.g. when loaded through GNU Radio). In these error cases, the libuhd path would be
```
  $PREFIX/lib/./libuhd.so
```
(with a no-op /. inserted) which would result in a technically correct library directory of `$PREFIX/lib/.` but an incorrect prefix directory of `$PREFIX/lib`.

With the normalization fix, the libuhd path is corrected to
```
  $PREFIX/lib/libuhd.so
```
and the subsequent path manipulation to get the library and prefix directories will work as intended.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

UHD host

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

I have implemented this change in my [UHD conda-forge package](https://github.com/conda-forge/uhd-feedstock). Previously, working with a B200mini, the firmware would be loaded successfully when using UHD tools but would fail to be loaded (due to the bad images path) when used with GNU Radio. With this fix, the firmware is loaded correctly in all cases.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
