### PR TITLE
tests: verify_fbs_test: check if git_exe is None

### DIFF
--- a/host/tests/verify_fbs_test.py
+++ b/host/tests/verify_fbs_test.py
@@ -24,9 +24,8 @@ class VerifyFBSTest(unittest.TestCase):
         spec = importlib.util.spec_from_file_location("update_fbs", utils_path)
         update_fbs = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(update_fbs)
-        try:
             git_exe = update_fbs.find_executable("git")
-        except RuntimeError:
+        if git_exe is None:
             # No git, no test. We pass b/c git is not a UHD dependency.
             return
         sys.argv.append('--verify')


### PR DESCRIPTION
# Pull Request Details
## Description
Previously `make test` would fail on `verify_fbs_test` if `git` is not installed. It was because there was no `RuntimeException` thrown. If the `git_exe` is not found, the variable is simply `None`.

This change removes the `try`/`except` block and instead uses a simple `if` statement.

## Related Issue
Fixes #364 

## Which devices/areas does this affect?
Probably none?

## Testing Done

```bash
# make test
...
      Start 44: verify_fbs_test
44/68 Test #44: verify_fbs_test ..................   Passed    0.09 sec
...
100% tests passed, 0 tests failed out of 68

Total Test time (real) =   2.38 sec
```

```bash
# python3.8 -m unittest discover -s /root/ettus-uhd/host/tests -p verify_fbs_test.*
/root/ettus-uhd/host/utils/update_fbs.py
Found git executable: None
.
----------------------------------------------------------------------
Ran 1 test in 0.002s

OK
```

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
