### PR TITLE
Typo fix in SystemVerilog testbench template

### DIFF
--- a/host/cmake/debian/README.Debian
+++ b/host/cmake/debian/README.Debian
@@ -34,7 +34,7 @@ uhd-host:
  directories. The utils include tools for managing the
  flash memory or EEPROM configuration of various USRPs.
 
-libuhd003:
+libuhd4.0.0:
  Small package just for the library itself.
 
 libuhd-dev:

--- a/host/cmake/debian/control
+++ b/host/cmake/debian/control
@@ -20,7 +20,10 @@ Build-Depends:  cmake,
                 pkg-config,
                 python3-dev,
                 python3-mako,
-                python3-requests
+                python3-numpy,
+                python3-requests,
+                python3-ruamel.yaml,
+                python3-setuptools
 Standards-Version: 3.9.7
 Homepage: https://www.ettus.com
 Vcs-Git: git://github.com/EttusResearch/uhd.git
@@ -30,7 +33,11 @@ Architecture: any
 Depends: adduser,
          libuhd4.0.0 (= ${binary:Version}),
          python3,
+         python3-mako,
+         python3-numpy,
          python3-requests,
+         python3-ruamel.yaml,
+         python3-setuptools,
          ${misc:Depends},
          ${shlibs:Depends}
 Recommends: curl, procps
@@ -65,7 +72,15 @@ Description: hardware driver for Ettus Research products
 Package: libuhd-dev
 Architecture: any
 Section: libdevel
-Depends: libuhd4.0.0 (= ${binary:Version}), python3, ${misc:Depends}, ${shlibs:Depends}
+Depends: libuhd4.0.0 (= ${binary:Version}),
+         python3,
+         python3-mako,
+         python3-numpy,
+         python3-requests,
+         python3-ruamel.yaml,
+         python3-setuptools,
+         ${misc:Depends},
+         ${shlibs:Depends}
 Suggests: gnuradio
 Description: universal hardware driver for Ettus Research products
  Host library for the USRP Hardware Driver for Ettus Research products.

--- a/host/docs/build.dox.in
+++ b/host/docs/build.dox.in
@@ -72,19 +72,22 @@ The directory to which you extract libusb must not contain spaces. This is to sa
   - The Python path needs to be added to the environment variables.
   - Install fundamental packages for Python: On Windows Terminal, navigate to Python scripts folder, e.g. `C:\local\Python37\Scripts`, and execute the following commands to install requests and numpy packages, respectively:
 
-    pip install requests
-    pip install numpy
+    pip3 install requests
+    pip3 install numpy
+    pip3 install ruamel.yaml
+    pip3 install six
+    pip3 install setuptools
 
   - For curses package installation:
     - Download URL: https://www.lfd.uci.edu/~gohlke/pythonlibs/
     - Download a package that is similar to the Python version, Windows System, and system processor and copy it to Python scripts folder. For example, for Python 3.7, 64-bit Windows, and x64-based processor, download the `curses-2.2-cp37-cp37m-win_amd64.whl`.
     - Install the package dependency, wheel package:
 
-    pip install wheel
+    pip3 install wheel
 
     - Install the curses package and include it to Python scripts:
 
-    python -m pip install curses-2.2-cp37-cp37m-win_amd64.whl
+    python3 -m pip3 install curses-2.2-cp37-cp37m-win_amd64.whl
 
 ### Mako
 
@@ -92,9 +95,9 @@ The directory to which you extract libusb must not contain spaces. This is to sa
 - **Minimum Version:** @PY_MAKO_MIN_VERSION@
 - **Usage:** build time (required)
 - **Download URL:** http://www.makotemplates.org/download.html
-- **Alternative method:** You can use `pip` or `easy_install` to install Mako from PyPi. To install it using 'pip' on Windows, navigate to Python scripts folder, e.g. `C:\local\Python37\Scripts`, and run the following command:
+- **Alternative method:** You can use `pip3` or `easy_install` to install Mako from PyPi. To install it using 'pip3' on Windows, navigate to Python scripts folder, e.g. `C:\local\Python37\Scripts`, and run the following command:
 
-    pip install mako
+    pip3 install mako
 
 ### Doxygen
 
@@ -123,7 +126,7 @@ or install msysGit from http://code.google.com/p/msysgit/downloads/list.
 
 You can install all the dependencies through the package manager:
 
-    sudo apt-get install libboost-all-dev libusb-1.0-0-dev python-mako doxygen python-docutils cmake build-essential
+    sudo apt-get install libboost-all-dev libusb-1.0-0-dev doxygen python3-docutils python3-mako python3-numpy python3-requests python3-ruamel.yaml python3-setuptools cmake build-essential
 
 Your actual command may differ.
 
@@ -131,11 +134,11 @@ Your actual command may differ.
 
 You can install all the dependencies through the package manager:
 
-    sudo yum -y install boost-devel libusb1-devel python-mako doxygen python-docutils cmake make gcc gcc-c++
+    sudo yum -y install boost-devel libusb1-devel doxygen python3-docutils python3-mako python3-numpy python3-requests python3-ruamel.yaml python3-setuptools cmake make gcc gcc-c++
 
 or
 
-    sudo dnf -y install boost-devel libusb1-devel python-mako doxygen python-docutils cmake make gcc gcc-c++
+    sudo dnf -y install boost-devel libusb1-devel doxygen python3-docutils python3-mako python3-numpy python3-requests python3-ruamel.yaml python3-setuptools cmake make gcc gcc-c++
 
 Your actual command may differ.
 

--- a/host/docs/usrp_n3xx.dox
+++ b/host/docs/usrp_n3xx.dox
@@ -534,7 +534,8 @@ The following motherboard sensors are always available:
 
 - `ref_locked`: This will check that all the daughterboards have locked to the
   external reference.
-- `temperature`: The temperature of the die itself
+- `temp`: The temperature of the die itself
+- `fan`: The current fan speed
 - `gps_lock`: GPS lock
 - `gps_time`: GPS time in seconds sin ce the epch
 - `gps_tpv`: A TPV report from GPSd serialized as JSON

--- a/host/include/uhd/types/device_addr.hpp
+++ b/host/include/uhd/types/device_addr.hpp
@@ -50,6 +50,13 @@ public:
     device_addr_t(const std::map<std::string, std::string>& info);
 
     /*!
+     * Looks for any key that matches the prefix.
+     * \param prefix string to compare keys to
+     * \return a bool true if found else false
+     */
+    bool has_key_with_prefix(const std::string& prefix) const;
+
+    /*!
      * Convert a device address into a pretty print string.
      * \return a printable string representing the device address
      */

--- a/host/include/uhd/utils/graph_utils.hpp
+++ b/host/include/uhd/utils/graph_utils.hpp
@@ -26,7 +26,9 @@ using block_port_def = std::tuple<std::string, boost::optional<size_t>>;
  *  some of their ports, so we can optionally include a port number.
  */
 static const std::vector<block_port_def> TERMINATOR_BLOCKS{
-    {NODE_ID_SEP, boost::none}, {"Radio", boost::none}, {"NullSrcSink", 0}};
+    block_port_def{NODE_ID_SEP, boost::none},
+    block_port_def{"Radio", boost::none},
+    block_port_def{"NullSrcSink", 0}};
 
 /*!
  *  Get a chain of blocks that statically connect back to a terminating block. This

--- a/host/lib/cal/database.cpp
+++ b/host/lib/cal/database.cpp
@@ -49,7 +49,9 @@ std::string get_cal_path_rc(const std::string& key)
 bool has_cal_data_rc(const std::string& key, const std::string&)
 {
     auto fs = rc::get_filesystem();
-    return fs.is_file(get_cal_path_rc(key));
+    const std::string cal_path(get_cal_path_rc(key));
+    UHD_LOG_TRACE(LOG_ID, "Checking for resource " << cal_path);
+    return fs.is_file(cal_path);
 }
 
 //! Return a byte array for a given cal resource

--- a/host/lib/cal/database.cpp
+++ b/host/lib/cal/database.cpp
@@ -11,9 +11,9 @@
 #include <uhd/utils/static.hpp>
 #include <cmrc/cmrc.hpp>
 #include <boost/filesystem.hpp>
+#include <array>
 #include <ctime>
 #include <fstream>
-#include <array>
 #include <tuple>
 #include <vector>
 
@@ -24,8 +24,8 @@ namespace rc = cmrc::rc;
 namespace fs = boost::filesystem;
 
 namespace {
-constexpr char LOG_ID[] = "CAL::DATABASE";
-constexpr char CAL_EXT[]          = ".cal";
+constexpr char LOG_ID[]  = "CAL::DATABASE";
+constexpr char CAL_EXT[] = ".cal";
 //! This value is just for sanity checking. We pick a value (in bytes) that we
 // are guaranteed to never exceed. Its only purpose is to avoid loading files
 // that can't possibly be valid cal data based on the filesize. This can avoid
@@ -193,12 +193,13 @@ std::vector<uint8_t> get_cal_data_flash(const std::string& key, const std::strin
  *****************************************************************************/
 typedef bool (*has_cal_data_fn)(const std::string&, const std::string&);
 typedef std::vector<uint8_t> (*get_cal_data_fn)(const std::string&, const std::string&);
+typedef std::tuple<source, has_cal_data_fn, get_cal_data_fn> cal_data_fn_tuple;
 // These are in order of priority!
 // clang-format off
-constexpr std::array<std::tuple<source, has_cal_data_fn, get_cal_data_fn>, 3> data_fns{{
-    {source::FILESYSTEM, &has_cal_data_fs,    &get_cal_data_fs   },
-    {source::FLASH,      &has_cal_data_flash, &get_cal_data_flash},
-    {source::RC,         &has_cal_data_rc,    &get_cal_data_rc   }
+constexpr std::array<cal_data_fn_tuple, 3> data_fns{{
+    cal_data_fn_tuple{source::FILESYSTEM, &has_cal_data_fs,    &get_cal_data_fs   },
+    cal_data_fn_tuple{source::FLASH,      &has_cal_data_flash, &get_cal_data_flash},
+    cal_data_fn_tuple{source::RC,         &has_cal_data_rc,    &get_cal_data_rc   }
 }};
 // clang-format on
 

--- a/host/lib/types/device_addr.cpp
+++ b/host/lib/types/device_addr.cpp
@@ -9,6 +9,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
 #include <boost/tokenizer.hpp>
+#include <algorithm>
 #include <regex>
 #include <sstream>
 #include <stdexcept>
@@ -49,6 +50,14 @@ device_addr_t::device_addr_t(const std::map<std::string, std::string>& info)
     for (auto& t : info) {
         this->set(t.first, t.second);
     }
+}
+
+bool device_addr_t::has_key_with_prefix(const std::string& prefix) const
+{
+    auto dev_keys = this->keys();
+    return std::any_of(dev_keys.begin(), dev_keys.end(), [prefix](const auto& key) {
+        return key.substr(0, prefix.size()) == prefix;
+    });
 }
 
 std::string device_addr_t::to_pp_string(void) const

--- a/host/lib/usrp/b100/b100_impl.cpp
+++ b/host/lib/usrp/b100/b100_impl.cpp
@@ -117,7 +117,7 @@ static device_addrs_t b100_find(const device_addr_t& hint)
             // this is a found b100 when the hint serial and name match or blank
             if ((not hint.has_key("name") or hint["name"] == new_addr["name"])
                 and (not hint.has_key("serial")
-                        or hint["serial"] == new_addr["serial"])) {
+                     or hint["serial"] == new_addr["serial"])) {
                 b100_addrs.push_back(new_addr);
             }
         }

--- a/host/lib/usrp/b100/b100_impl.cpp
+++ b/host/lib/usrp/b100/b100_impl.cpp
@@ -44,8 +44,14 @@ static device_addrs_t b100_find(const device_addr_t& hint)
 
     // Return an empty list of addresses when an address or resource is specified,
     // since an address and resource is intended for a different, non-USB, device.
-    if (hint.has_key("addr") || hint.has_key("resource"))
+    if (hint.has_key("addr"))
         return b100_addrs;
+
+    if (hint.has_key_with_prefix("resource")) {
+        UHD_LOG_TRACE(
+            "B100 FIND", "Returning early, PCIe is not supported with b100 devices.");
+        return b100_addrs;
+    }
 
     uint16_t vid, pid;
 

--- a/host/lib/usrp/b200/b200_impl.cpp
+++ b/host/lib/usrp/b200/b200_impl.cpp
@@ -182,8 +182,14 @@ static device_addrs_t b200_find(const device_addr_t& hint)
     // Return an empty list of addresses when an address or resource is specified,
     // since an address and resource is intended for a different, non-USB, device.
     for (device_addr_t hint_i : separate_device_addr(hint)) {
-        if (hint_i.has_key("addr") || hint_i.has_key("resource"))
+        if (hint_i.has_key("addr"))
             return b200_addrs;
+
+        if (hint.has_key_with_prefix("resource")) {
+            UHD_LOG_TRACE(
+                "B200 FIND", "Returning early, PCIe is not supported with b200 devices.");
+            return b200_addrs;
+        }
     }
 
     // Important note:

--- a/host/lib/usrp/b200/b200_impl.cpp
+++ b/host/lib/usrp/b200/b200_impl.cpp
@@ -8,6 +8,7 @@
 #include "b200_impl.hpp"
 #include "../../transport/libusb1_base.hpp"
 #include "b200_regs.hpp"
+#include <uhd/cal/database.hpp>
 #include <uhd/config.hpp>
 #include <uhd/exception.hpp>
 #include <uhd/transport/usb_control.hpp>
@@ -17,7 +18,6 @@
 #include <uhd/utils/paths.hpp>
 #include <uhd/utils/safe_call.hpp>
 #include <uhd/utils/static.hpp>
-#include <uhd/cal/database.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/functional/hash.hpp>
@@ -251,7 +251,7 @@ static device_addrs_t b200_find(const device_addr_t& hint)
             // this is a found b200 when the hint serial and name match or blank
             if ((not hint.has_key("name") or hint["name"] == new_addr["name"])
                 and (not hint.has_key("serial")
-                        or hint["serial"] == new_addr["serial"])) {
+                     or hint["serial"] == new_addr["serial"])) {
                 b200_addrs.push_back(new_addr);
             }
         }
@@ -984,9 +984,8 @@ void b200_impl::setup_radio(const size_t dspno)
     // b2xx_power_cal_$dir_$ant, depending on the form factor.
     // $dir is either "tx" or "rx", and "ant" is either "tx_rx" or "rx2" (i.e.,
     // sanitized version of the antenna names that work in filenames.
-    const std::string cal_key_base = (_product == B200MINI or _product == B205MINI)
-                                         ? "b2xxmini_pwr_"
-                                         : "b2xx_pwr_";
+    const std::string cal_key_base =
+        (_product == B200MINI or _product == B205MINI) ? "b2xxmini_pwr_" : "b2xx_pwr_";
     for (direction_t dir : std::vector<direction_t>{RX_DIRECTION, TX_DIRECTION}) {
         const std::string dir_key = (dir == RX_DIRECTION) ? "rx" : "tx";
         const std::string key     = std::string(((dir == RX_DIRECTION) ? "RX" : "TX"))
@@ -1148,7 +1147,7 @@ void b200_impl::enforce_tick_rate_limits(
 double b200_impl::set_tick_rate(const double new_tick_rate)
 {
     UHD_LOGGER_INFO("B200") << (boost::format("Asking for clock rate %.6f MHz... ")
-                                   % (new_tick_rate / 1e6))
+                                % (new_tick_rate / 1e6))
                             << std::flush;
     check_tick_rate_with_current_streamers(new_tick_rate); // Defined in b200_io_impl.cpp
 

--- a/host/lib/usrp/mpmd/mpmd_find.cpp
+++ b/host/lib/usrp/mpmd/mpmd_find.cpp
@@ -224,6 +224,12 @@ device_addrs_t mpmd_find(const device_addr_t& hint_)
             return {};
         }
     }
+    if (hint_.has_key_with_prefix("resource")) {
+        UHD_LOG_TRACE(
+            "MPMD FIND", "Returning early, PCIe is not support with mpm devices.");
+        return {};
+    }
+
     UHD_LOG_TRACE("MPMD FIND", "Finding with " << hints.size() << " different hint(s).");
 
     // Scenario 1): User gave us at least one address

--- a/host/lib/usrp/mpmd/mpmd_find.cpp
+++ b/host/lib/usrp/mpmd/mpmd_find.cpp
@@ -9,11 +9,11 @@
 #include "mpmd_devices.hpp"
 #include "mpmd_impl.hpp"
 #include "mpmd_link_if_mgr.hpp"
-#include <uhdlib/utils/serial_number.hpp>
 #include <uhd/transport/if_addrs.hpp>
 #include <uhd/transport/udp_simple.hpp>
 #include <uhd/types/device_addr.hpp>
 #include <uhdlib/utils/prefs.hpp>
+#include <uhdlib/utils/serial_number.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
 #include <future>
@@ -65,7 +65,8 @@ device_addrs_t mpmd_find_with_addr(
         const char* reply        = (const char*)buff;
         std::string reply_string = std::string(reply);
         std::vector<std::string> result;
-        boost::algorithm::split(result,
+        boost::algorithm::split(
+            result,
             reply_string,
             [](const char& in) { return in == ';'; },
             boost::token_compress_on);
@@ -102,7 +103,8 @@ device_addrs_t mpmd_find_with_addr(
         // device_args
         for (const auto& el : result) {
             std::vector<std::string> value;
-            boost::algorithm::split(value,
+            boost::algorithm::split(
+                value,
                 el,
                 [](const char& in) { return in == '='; },
                 boost::token_compress_on);
@@ -112,11 +114,12 @@ device_addrs_t mpmd_find_with_addr(
         }
         // filter the discovered device below by matching optional keys
         if ((not hint_.has_key("name") or hint_["name"] == new_addr["name"])
-            and (not hint_.has_key("serial") or utils::serial_numbers_match(hint_["serial"], new_addr["serial"]))
+            and (not hint_.has_key("serial")
+                 or utils::serial_numbers_match(hint_["serial"], new_addr["serial"]))
             and (not hint_.has_key("type") or hint_["type"] == new_addr["type"]
-                    or hint_["type"] == MPM_CATCHALL_DEVICE_TYPE)
+                 or hint_["type"] == MPM_CATCHALL_DEVICE_TYPE)
             and (not hint_.has_key("product")
-                    or hint_["product"] == new_addr["product"])) {
+                 or hint_["product"] == new_addr["product"])) {
             UHD_LOG_TRACE(
                 "MPMD FIND", "Found device that matches hints: " << new_addr.to_string());
             addrs.push_back(new_addr);
@@ -209,8 +212,7 @@ device_addrs_t mpmd_find(const device_addr_t& hint_)
 #endif
     device_addrs_t hints_without_prefs = separate_device_addr(hint_);
     device_addrs_t hints;
-    for (size_t i = 0; i < hints_without_prefs.size(); i++)
-    {
+    for (size_t i = 0; i < hints_without_prefs.size(); i++) {
         hints.push_back(prefs::get_usrp_args(hints_without_prefs[i]));
     }
 
@@ -227,7 +229,7 @@ device_addrs_t mpmd_find(const device_addr_t& hint_)
     // Scenario 1): User gave us at least one address
     if (not hints.empty()
         and (hints[0].has_key(xport::FIRST_ADDR_KEY)
-                or hints[0].has_key(MGMT_ADDR_KEY))) {
+             or hints[0].has_key(MGMT_ADDR_KEY))) {
         // Note: We don't try and connect to the devices in this mode, because
         // we only get here if the user specified addresses, and we assume she
         // knows what she's doing.

--- a/host/lib/usrp/usrp1/usrp1_impl.cpp
+++ b/host/lib/usrp/usrp1/usrp1_impl.cpp
@@ -47,8 +47,14 @@ static device_addrs_t usrp1_find(const device_addr_t& hint)
 
     // Return an empty list of addresses when an address or resource is specified,
     // since an address and resource is intended for a different, non-USB, device.
-    if (hint.has_key("addr") || hint.has_key("resource"))
+    if (hint.has_key("addr"))
         return usrp1_addrs;
+
+    if (hint.has_key_with_prefix("resource")) {
+        UHD_LOG_TRACE(
+            "USRP1 FIND", "Returning early, PCIe is not supported with usrp1 devices.");
+        return usrp1_addrs;
+    }
 
     uint16_t vid, pid;
 
@@ -121,7 +127,7 @@ static device_addrs_t usrp1_find(const device_addr_t& hint)
             // this is a found usrp1 when the hint serial and name match or blank
             if ((not hint.has_key("name") or hint["name"] == new_addr["name"])
                 and (not hint.has_key("serial")
-                        or hint["serial"] == new_addr["serial"])) {
+                     or hint["serial"] == new_addr["serial"])) {
                 usrp1_addrs.push_back(new_addr);
             }
         }

--- a/host/lib/usrp/usrp2/usrp2_impl.cpp
+++ b/host/lib/usrp/usrp2/usrp2_impl.cpp
@@ -166,7 +166,7 @@ device_addrs_t usrp2_find(const device_addr_t& hint_)
             // filter the discovered device below by matching optional keys
             if ((not hint.has_key("name") or hint["name"] == new_addr["name"])
                 and (not hint.has_key("serial")
-                        or hint["serial"] == new_addr["serial"])) {
+                     or hint["serial"] == new_addr["serial"])) {
                 usrp2_addrs.push_back(new_addr);
             }
 

--- a/host/lib/usrp/usrp2/usrp2_impl.cpp
+++ b/host/lib/usrp/usrp2/usrp2_impl.cpp
@@ -68,8 +68,11 @@ device_addrs_t usrp2_find(const device_addr_t& hint_)
 
     // Return an empty list of addresses when a resource is specified,
     // since a resource is intended for a different, non-USB, device.
-    if (hint.has_key("resource"))
+    if (hint.has_key_with_prefix("resource")) {
+        UHD_LOG_TRACE(
+            "USRP2 FIND", "Returning early, PCIe is not supported with usrp2 devices.");
         return usrp2_addrs;
+    }
 
     // if no address was specified, send a broadcast on each interface
     if (not hint.has_key("addr")) {

--- a/host/lib/usrp/x300/x300_impl.cpp
+++ b/host/lib/usrp/x300/x300_impl.cpp
@@ -100,7 +100,9 @@ device_addrs_t x300_find(const device_addr_t& hint_)
         return reply_addrs;
     }
 
-    if (!hint.has_key("resource")) {
+    bool has_resource_key = hint.has_key_with_prefix("resource");
+
+    if (!has_resource_key) {
         // otherwise, no address was specified, send a broadcast on each interface
         for (const transport::if_addrs_t& if_addrs : transport::get_if_addrs()) {
             // avoid the loopback device
@@ -135,7 +137,7 @@ device_addrs_t x300_find(const device_addr_t& hint_)
         }
     }
 
-    device_addrs_t pcie_addrs = pcie_manager::find(hint, hint.has_key("resource"));
+    device_addrs_t pcie_addrs = pcie_manager::find(hint, has_resource_key);
     if (not pcie_addrs.empty()) {
         addrs.insert(addrs.end(), pcie_addrs.begin(), pcie_addrs.end());
     }

--- a/host/lib/usrp_clock/octoclock/octoclock_impl.cpp
+++ b/host/lib/usrp_clock/octoclock/octoclock_impl.cpp
@@ -151,7 +151,7 @@ device_addrs_t octoclock_find(const device_addr_t& hint)
                     // Filter based on optional keys (if any)
                     if ((not _hint.has_key("name") or (_hint["name"] == new_addr["name"]))
                         and (not _hint.has_key("serial")
-                                or (_hint["serial"] == new_addr["serial"]))) {
+                             or (_hint["serial"] == new_addr["serial"]))) {
                         octoclock_addrs.push_back(new_addr);
                     }
                 }

--- a/host/lib/usrp_clock/octoclock/octoclock_impl.cpp
+++ b/host/lib/usrp_clock/octoclock/octoclock_impl.cpp
@@ -71,8 +71,11 @@ device_addrs_t octoclock_find(const device_addr_t& hint)
 
     // Return an empty list of addresses when a resource is specified,
     // since a resource is intended for a different, non-USB, device.
-    if (hint.has_key("resource"))
+    if (hint.has_key_with_prefix("resource")) {
+        UHD_LOG_TRACE("OCTOCLOCK FIND",
+            "Returning early, PCIe is not supported with octoclock devices.");
         return octoclock_addrs;
+    }
 
     // If no address was specified, send a broadcast on each interface
     if (not _hint.has_key("addr")) {

--- a/host/lib/utils/graph_utils.cpp
+++ b/host/lib/utils/graph_utils.cpp
@@ -52,7 +52,7 @@ std::vector<graph_edge_t> get_block_chain(const rfnoc_graph::sptr graph,
             if ((source_chain)
                     ? (edge.src_blockid == current_block && edge.src_port == current_port)
                     : (edge.dst_blockid == current_block
-                          && edge.dst_port == current_port)) {
+                        && edge.dst_port == current_port)) {
                 // If the current block is the edge's source, make the edge's
                 // destination the current block
                 next_found = true;
@@ -101,7 +101,7 @@ void connect_through_blocks(rfnoc_graph::sptr graph,
             // input port match what we're looking for
             return dst_found
                    || (dst_blk.to_string() == edge.dst_blockid
-                          && dst_port == edge.dst_port);
+                       && dst_port == edge.dst_port);
         });
     // If our dst_blk is in the chain already, make sure its the last element and continue
     if (dst_found) {
@@ -129,25 +129,27 @@ void connect_through_blocks(rfnoc_graph::sptr graph,
     // call connect on the src and dst blocks since calling
     // connect on SEPs is invalid
     std::string src_to_sep_id;
-    size_t src_to_sep_port;
+    size_t src_to_sep_port = 0;
     std::string sep_to_dst_id;
-    size_t sep_to_dst_port;
+    size_t sep_to_dst_port  = 0;
     bool has_sep_connection = false;
 
     for (auto edge : block_chain) {
-        if(uhd::rfnoc::block_id_t(edge.dst_blockid).match(uhd::rfnoc::NODE_ID_SEP)) {
+        if (uhd::rfnoc::block_id_t(edge.dst_blockid).match(uhd::rfnoc::NODE_ID_SEP)) {
             has_sep_connection = true;
-            src_to_sep_id = edge.src_blockid;
-            src_to_sep_port = edge.src_port;
-        } else if(uhd::rfnoc::block_id_t(edge.src_blockid).match(uhd::rfnoc::NODE_ID_SEP)) {
+            src_to_sep_id      = edge.src_blockid;
+            src_to_sep_port    = edge.src_port;
+        } else if (uhd::rfnoc::block_id_t(edge.src_blockid)
+                       .match(uhd::rfnoc::NODE_ID_SEP)) {
             has_sep_connection = true;
-            sep_to_dst_id = edge.dst_blockid;
-            sep_to_dst_port = edge.dst_port;
-        } else{
-            graph->connect(edge.src_blockid, edge.src_port, edge.dst_blockid, edge.dst_port);
+            sep_to_dst_id      = edge.dst_blockid;
+            sep_to_dst_port    = edge.dst_port;
+        } else {
+            graph->connect(
+                edge.src_blockid, edge.src_port, edge.dst_blockid, edge.dst_port);
         }
     }
-    if(has_sep_connection) {
+    if (has_sep_connection) {
         graph->connect(src_to_sep_id, src_to_sep_port, sep_to_dst_id, sep_to_dst_port);
     }
 }

--- a/host/utils/rfnoc_blocktool/templates/rfnoc_block_template_tb.sv.mako
+++ b/host/utils/rfnoc_blocktool/templates/rfnoc_block_template_tb.sv.mako
@@ -123,14 +123,14 @@ module rfnoc_block_${config['module_name']}_tb;
   // Map the array of BFMs to a flat vector for the DUT connections
   for (genvar i = 0; i < NUM_PORTS_I; i++) begin : gen_dut_input_connections
     // Connect BFM master to DUT slave port
-    assign s_rfnoc_chdr_tdata[CHDR_W*i+:CHDR_W] = m_chdr[i].tdata;
+    assign s_rfnoc_chdr_tdata[CHDR_W*(i+1)-1:CHDR_W*i] = m_chdr[i].tdata;
     assign s_rfnoc_chdr_tlast[i]                = m_chdr[i].tlast;
     assign s_rfnoc_chdr_tvalid[i]               = m_chdr[i].tvalid;
     assign m_chdr[i].tready                     = s_rfnoc_chdr_tready[i];
   end
   for (genvar i = 0; i < NUM_PORTS_O; i++) begin : gen_dut_output_connections
     // Connect BFM slave to DUT master port
-    assign s_chdr[i].tdata        = m_rfnoc_chdr_tdata[CHDR_W*i+:CHDR_W];
+    assign s_chdr[i].tdata        = m_rfnoc_chdr_tdata[CHDR_W*(i+1)-1:CHDR_W*i];
     assign s_chdr[i].tlast        = m_rfnoc_chdr_tlast[i];
     assign s_chdr[i].tvalid       = m_rfnoc_chdr_tvalid[i];
     assign m_rfnoc_chdr_tready[i] = s_chdr[i].tready;


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->
See commit e57f59c.
## Description
Without these changes, the DUT is never properly connected to the Bus Functional Model.

## Related Issue
None that we're aware of.

## Which devices/areas does this affect?
Autogenerated testbenches for (user-defined) RFNoC blocks.

## Testing Done
An autogenerated testbench of ours failed. With these changes, it ran successfully.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
