### PR TITLE
msgpack/predef: add riscV support

### DIFF
--- a/host/lib/deps/rpclib/include/rpc/msgpack/predef/architecture.h
+++ b/host/lib/deps/rpclib/include/rpc/msgpack/predef/architecture.h
@@ -18,6 +18,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 #include <rpc/msgpack/predef/architecture/parisc.h>
 #include <rpc/msgpack/predef/architecture/ppc.h>
 #include <rpc/msgpack/predef/architecture/pyramid.h>
+#include <rpc/msgpack/predef/architecture/riscv.h>
 #include <rpc/msgpack/predef/architecture/rs6k.h>
 #include <rpc/msgpack/predef/architecture/sparc.h>
 #include <rpc/msgpack/predef/architecture/superh.h>

--- a/host/lib/deps/rpclib/include/rpc/msgpack/predef/architecture/riscv.h
+++ b/host/lib/deps/rpclib/include/rpc/msgpack/predef/architecture/riscv.h
@@ -1,0 +1,48 @@
+/*
+Copyright Andreas Schwab 2019
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_ARCHITECTURE_RISCV_H
+#define BOOST_PREDEF_ARCHITECTURE_RISCV_H
+
+#include <boost/predef/version_number.h>
+#include <boost/predef/make.h>
+
+/* tag::reference[]
+= `BOOST_ARCH_RISCV`
+
+http://en.wikipedia.org/wiki/RISC-V[RISC-V] architecture.
+
+[options="header"]
+|===
+| {predef_symbol} | {predef_version}
+
+| `+__riscv+` | {predef_detection}
+|===
+*/ // end::reference[]
+
+#define BOOST_ARCH_RISCV BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if defined(__riscv)
+#   undef BOOST_ARCH_RISCV
+#   define BOOST_ARCH_RISCV BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_ARCH_RISCV
+#   define BOOST_ARCH_RISCV_AVAILABLE
+#endif
+
+#if BOOST_ARCH_RISCV
+#   undef BOOST_ARCH_WORD_BITS_32
+#   define BOOST_ARCH_WORD_BITS_32 BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#define BOOST_ARCH_RISCV_NAME "RISC-V"
+
+#endif
+
+#include <boost/predef/detail/test.h>
+BOOST_PREDEF_DECLARE_TEST(BOOST_ARCH_RISCV,BOOST_ARCH_RISCV_NAME)

--- a/host/lib/deps/rpclib/include/rpc/msgpack/predef/other/endian.h
+++ b/host/lib/deps/rpclib/include/rpc/msgpack/predef/other/endian.h
@@ -127,7 +127,8 @@ information and acquired knowledge:
         defined(__AARCH64EL__) || \
         defined(_MIPSEL) || \
         defined(__MIPSEL) || \
-        defined(__MIPSEL__)
+        defined(__MIPSEL__) || \
+        defined(__riscv)
 #       undef MSGPACK_ENDIAN_LITTLE_BYTE
 #       define MSGPACK_ENDIAN_LITTLE_BYTE MSGPACK_VERSION_NUMBER_AVAILABLE
 #   endif


### PR DESCRIPTION
# Pull Request Details
Fix msgpack endian detection when CPU target architecture is `riscV`. 

## Description

Adapt riscV implementation based on [predef](https://github.com/boostorg/predef)

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

When the target CPU is riscV msgpack is unable to detect endianness with a list of errors like:
```
uhd/host/lib/deps/rpclib/include/rpc/msgpack/pack.hpp:190:2: error: #error msgpack-c supports only big endian and little endian
  190 | #error msgpack-c supports only big endian and little endian
      |  ^~~~~
```

and with subsequent errors:
```
uhd0/host/lib/deps/rpclib/include/rpc/msgpack/pack.hpp:236:46: error: there are no arguments to 'take8_8' that depend on a template parameter, so a declaration of 'take8_8' must be available [-fpermissive]
  236 |     char buf[2] = {static_cast<char>(0xccu), take8_8(d)};
      |      
```
this PR adapt riscV support to fix this issue

## Checklist

- [X ] I have read the CONTRIBUTING document.
- [X ] My code follows the code style of this project. See CODING.md.
