### PR TITLE
Boost fixes for UHD-3.9.LTS

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -263,6 +263,10 @@ IF(MSVC)
     ENDIF(BOOST_ALL_DYN_LINK)
 ENDIF(MSVC)
 
+# UHD 3.9 still uses global placeholders (_1, _2, ...) from Boost which
+# need to be enabled explicitly for some Boost versions
+ADD_DEFINITIONS(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
+
 SET(Boost_ADDITIONAL_VERSIONS
     "1.46.0" "1.46" "1.47.0" "1.47" "1.48.0" "1.48" "1.48.0" "1.49" "1.50.0" "1.50"
     "1.51.0" "1.51" "1.52.0" "1.52" "1.53.0" "1.53" "1.54.0" "1.54" "1.55.0" "1.55"

--- a/host/examples/benchmark_rate.cpp
+++ b/host/examples/benchmark_rate.cpp
@@ -24,6 +24,7 @@
 #include <boost/thread/thread.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/bind.hpp>
 //#include <boost/atomic.hpp>
 #include <iostream>
 #include <complex>

--- a/host/examples/network_relay.cpp
+++ b/host/examples/network_relay.cpp
@@ -22,6 +22,7 @@
 #include <boost/thread/thread.hpp>
 #include <boost/format.hpp>
 #include <boost/asio.hpp>
+#include <boost/bind.hpp>
 #include <iostream>
 #include <csignal>
 #include <vector>

--- a/host/examples/rx_samples_to_file.cpp
+++ b/host/examples/rx_samples_to_file.cpp
@@ -23,6 +23,7 @@
 #include <boost/program_options.hpp>
 #include <boost/format.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind.hpp>
 #include <iostream>
 #include <fstream>
 #include <csignal>

--- a/host/examples/test_clock_synch.cpp
+++ b/host/examples/test_clock_synch.cpp
@@ -20,6 +20,7 @@
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
 #include <boost/thread/thread.hpp>
+#include <boost/bind.hpp>
 
 #include <uhd/device.hpp>
 #include <uhd/exception.hpp>

--- a/host/examples/txrx_loopback_to_file.cpp
+++ b/host/examples/txrx_loopback_to_file.cpp
@@ -29,6 +29,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/bind.hpp>
 #include <iostream>
 #include <fstream>
 #include <csignal>

--- a/host/include/uhd/types/endianness.hpp
+++ b/host/include/uhd/types/endianness.hpp
@@ -20,6 +20,21 @@
 
 #include <uhd/config.hpp>
 
+/******************************************************************************
+ * Detect host endianness
+ *****************************************************************************/
+#include <boost/predef/other/endian.h>
+
+// In Boost 1.55, the meaning of the macros changed. They are now always
+// defined, but don't always have the same value.
+#if BOOST_ENDIAN_BIG_BYTE
+#    define UHD_BIG_ENDIAN
+#elif BOOST_ENDIAN_LITTLE_BYTE
+#    define UHD_LITTLE_ENDIAN
+#else
+#    error "Unsupported endianness!"
+#endif
+
 namespace uhd{
 
     enum endianness_t {

--- a/host/include/uhd/utils/byteswap.hpp
+++ b/host/include/uhd/utils/byteswap.hpp
@@ -19,6 +19,7 @@
 #define INCLUDED_UHD_UTILS_BYTESWAP_HPP
 
 #include <uhd/config.hpp>
+#include <uhd/types/endianness.hpp>
 #include <boost/cstdint.hpp>
 
 /*! \file byteswap.hpp

--- a/host/include/uhd/utils/byteswap.ipp
+++ b/host/include/uhd/utils/byteswap.ipp
@@ -99,12 +99,10 @@
 /***********************************************************************
  * Define the templated network to/from host conversions
  **********************************************************************/
-#include <boost/detail/endian.hpp>
-
 namespace uhd {
 
 template<typename T> UHD_INLINE T ntohx(T num){
-    #ifdef BOOST_BIG_ENDIAN
+    #ifdef UHD_BIG_ENDIAN
         return num;
     #else
         return uhd::byteswap(num);
@@ -112,7 +110,7 @@ template<typename T> UHD_INLINE T ntohx(T num){
 }
 
 template<typename T> UHD_INLINE T htonx(T num){
-    #ifdef BOOST_BIG_ENDIAN
+    #ifdef UHD_BIG_ENDIAN
         return num;
     #else
         return uhd::byteswap(num);
@@ -120,7 +118,7 @@ template<typename T> UHD_INLINE T htonx(T num){
 }
 
 template<typename T> UHD_INLINE T wtohx(T num){
-    #ifdef BOOST_BIG_ENDIAN
+    #ifdef UHD_BIG_ENDIAN
         return uhd::byteswap(num);
     #else
         return num;
@@ -128,7 +126,7 @@ template<typename T> UHD_INLINE T wtohx(T num){
 }
 
 template<typename T> UHD_INLINE T htowx(T num){
-    #ifdef BOOST_BIG_ENDIAN
+    #ifdef UHD_BIG_ENDIAN
         return uhd::byteswap(num);
     #else
         return num;

--- a/host/lib/convert/convert_with_tables.cpp
+++ b/host/lib/convert/convert_with_tables.cpp
@@ -167,7 +167,7 @@ private:
  * Factory functions and registration
  **********************************************************************/
 
-#ifdef BOOST_BIG_ENDIAN
+#ifdef UHD_BIG_ENDIAN
 #  define SHIFT_PAIR0 16, 0
 #  define SHIFT_PAIR1 0, 16
 #  define BE_SWAP false

--- a/host/lib/transport/chdr.cpp
+++ b/host/lib/transport/chdr.cpp
@@ -20,7 +20,7 @@
 #include <uhd/exception.hpp>
 
 //define the endian macros to convert integers
-#ifdef BOOST_BIG_ENDIAN
+#ifdef UHD_BIG_ENDIAN
     #define BE_MACRO(x) (x)
     #define LE_MACRO(x) uhd::byteswap(x)
 #else

--- a/host/lib/transport/gen_vrt_if_packet.py
+++ b/host/lib/transport/gen_vrt_if_packet.py
@@ -33,11 +33,11 @@ TMPL_TEXT = """<% import time %>
 #include <uhd/exception.hpp>
 #include <uhd/transport/vrt_if_packet.hpp>
 #include <uhd/utils/byteswap.hpp>
-#include <boost/detail/endian.hpp>
+#include <uhd/types/endianness.hpp>
 #include <vector>
 
 //define the endian macros to convert integers
-#ifdef BOOST_BIG_ENDIAN
+#ifdef UHD_BIG_ENDIAN
     #define BE_MACRO(x) (x)
     #define LE_MACRO(x) uhd::byteswap(x)
 #else

--- a/host/lib/transport/super_send_packet_handler.hpp
+++ b/host/lib/transport/super_send_packet_handler.hpp
@@ -32,6 +32,7 @@
 #include <boost/thread/thread_time.hpp>
 #include <boost/foreach.hpp>
 #include <boost/function.hpp>
+#include <boost/bind.hpp>
 #include <iostream>
 #include <vector>
 

--- a/host/lib/transport/xport_benchmarker.cpp
+++ b/host/lib/transport/xport_benchmarker.cpp
@@ -16,6 +16,7 @@
 //
 
 #include "xport_benchmarker.hpp"
+#include <boost/bind.hpp>
 
 namespace uhd { namespace transport {
 

--- a/host/lib/usrp/b100/b100_impl.cpp
+++ b/host/lib/usrp/b100/b100_impl.cpp
@@ -30,6 +30,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/bind.hpp>
 #include <cstdio>
 #include <iostream>
 

--- a/host/lib/usrp/b200/b200_iface.cpp
+++ b/host/lib/usrp/b200/b200_iface.cpp
@@ -27,6 +27,7 @@
 #include <boost/cstdint.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/format.hpp>
+#include <boost/bind.hpp>
 #include <fstream>
 #include <string>
 #include <vector>

--- a/host/lib/usrp/b200/b200_impl.cpp
+++ b/host/lib/usrp/b200/b200_impl.cpp
@@ -34,6 +34,7 @@
 #include <boost/functional/hash.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/weak_ptr.hpp>
+#include <boost/bind.hpp>
 #include <cstdio>
 #include <ctime>
 #include <cmath>

--- a/host/lib/usrp/common/ad936x_manager.cpp
+++ b/host/lib/usrp/common/ad936x_manager.cpp
@@ -20,6 +20,7 @@
 #include <boost/foreach.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/thread/thread.hpp>
+#include <boost/bind.hpp>
 
 using namespace uhd;
 using namespace uhd::usrp;

--- a/host/lib/usrp/cores/rx_dsp_core_3000.cpp
+++ b/host/lib/usrp/cores/rx_dsp_core_3000.cpp
@@ -25,6 +25,7 @@
 #include <boost/thread/thread.hpp> //thread sleep
 #include <boost/math/special_functions/round.hpp>
 #include <boost/math/special_functions/sign.hpp>
+#include <boost/bind.hpp>
 #include <algorithm>
 #include <cmath>
 

--- a/host/lib/usrp/cores/tx_dsp_core_3000.cpp
+++ b/host/lib/usrp/cores/tx_dsp_core_3000.cpp
@@ -24,6 +24,7 @@
 #include <boost/math/special_functions/round.hpp>
 #include <boost/math/special_functions/sign.hpp>
 #include <boost/thread/thread.hpp> //sleep
+#include <boost/bind.hpp>
 #include <algorithm>
 #include <cmath>
 

--- a/host/lib/usrp/dboard/db_cbx.cpp
+++ b/host/lib/usrp/dboard/db_cbx.cpp
@@ -18,6 +18,7 @@
 #include "db_sbx_common.hpp"
 #include <boost/algorithm/string.hpp>
 #include <boost/math/special_functions/round.hpp>
+#include <boost/bind.hpp>
 
 using namespace uhd;
 using namespace uhd::usrp;

--- a/host/lib/usrp/dboard/db_dbsrx.cpp
+++ b/host/lib/usrp/dboard/db_dbsrx.cpp
@@ -34,6 +34,7 @@
 #include <boost/format.hpp>
 #include <boost/thread.hpp>
 #include <boost/math/special_functions/round.hpp>
+#include <boost/bind.hpp>
 #include <utility>
 #include <cmath>
 

--- a/host/lib/usrp/dboard/db_dbsrx2.cpp
+++ b/host/lib/usrp/dboard/db_dbsrx2.cpp
@@ -31,6 +31,7 @@
 #include <boost/format.hpp>
 #include <boost/thread.hpp>
 #include <boost/math/special_functions/round.hpp>
+#include <boost/bind.hpp>
 #include <utility>
 
 using namespace uhd;

--- a/host/lib/usrp/dboard/db_sbx_common.cpp
+++ b/host/lib/usrp/dboard/db_sbx_common.cpp
@@ -16,6 +16,7 @@
 //
 
 #include "db_sbx_common.hpp"
+#include <boost/bind.hpp>
 
 using namespace uhd;
 using namespace uhd::usrp;

--- a/host/lib/usrp/dboard/db_tvrx.cpp
+++ b/host/lib/usrp/dboard/db_tvrx.cpp
@@ -42,6 +42,7 @@
 #include <boost/thread.hpp>
 #include <boost/array.hpp>
 #include <boost/math/special_functions/round.hpp>
+#include <boost/bind.hpp>
 #include <utility>
 #include <cmath>
 #include <cfloat>

--- a/host/lib/usrp/dboard/db_tvrx2.cpp
+++ b/host/lib/usrp/dboard/db_tvrx2.cpp
@@ -66,6 +66,7 @@
 #include <boost/thread.hpp>
 #include <boost/array.hpp>
 #include <boost/math/special_functions/round.hpp>
+#include <boost/bind.hpp>
 #include <utility>
 #include <cmath>
 

--- a/host/lib/usrp/dboard/db_ubx.cpp
+++ b/host/lib/usrp/dboard/db_ubx.cpp
@@ -34,6 +34,7 @@
 #include <boost/thread.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/bind.hpp>
 #include <map>
 #include "max287x.hpp"
 

--- a/host/lib/usrp/dboard/db_wbx_common.cpp
+++ b/host/lib/usrp/dboard/db_wbx_common.cpp
@@ -22,6 +22,7 @@
 #include <uhd/utils/assert_has.hpp>
 #include <uhd/utils/algorithm.hpp>
 #include <uhd/utils/msg.hpp>
+#include <boost/bind.hpp>
 
 using namespace uhd;
 using namespace uhd::usrp;

--- a/host/lib/usrp/dboard/db_wbx_simple.cpp
+++ b/host/lib/usrp/dboard/db_wbx_simple.cpp
@@ -27,6 +27,7 @@
 #include <uhd/utils/assert_has.hpp>
 #include <uhd/usrp/dboard_manager.hpp>
 #include <boost/assign/list_of.hpp>
+#include <boost/bind.hpp>
 
 using namespace uhd;
 using namespace uhd::usrp;

--- a/host/lib/usrp/dboard/db_wbx_version2.cpp
+++ b/host/lib/usrp/dboard/db_wbx_version2.cpp
@@ -31,6 +31,7 @@
 #include <boost/format.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/bind.hpp>
 
 using namespace uhd;
 using namespace uhd::usrp;

--- a/host/lib/usrp/dboard/db_wbx_version3.cpp
+++ b/host/lib/usrp/dboard/db_wbx_version3.cpp
@@ -30,6 +30,7 @@
 #include <boost/format.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/bind.hpp>
 
 using namespace uhd;
 using namespace uhd::usrp;

--- a/host/lib/usrp/dboard/db_wbx_version4.cpp
+++ b/host/lib/usrp/dboard/db_wbx_version4.cpp
@@ -30,6 +30,7 @@
 #include <boost/format.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/bind.hpp>
 
 using namespace uhd;
 using namespace uhd::usrp;

--- a/host/lib/usrp/dboard/db_xcvr2450.cpp
+++ b/host/lib/usrp/dboard/db_xcvr2450.cpp
@@ -62,6 +62,7 @@
 #include <boost/format.hpp>
 #include <boost/thread.hpp>
 #include <boost/math/special_functions/round.hpp>
+#include <boost/bind.hpp>
 #include <utility>
 
 using namespace uhd;

--- a/host/lib/usrp/e300/e300_fifo_config.cpp
+++ b/host/lib/usrp/e300/e300_fifo_config.cpp
@@ -18,6 +18,7 @@
 #ifdef E300_NATIVE
 
 #include <boost/cstdint.hpp>
+#include <boost/bind.hpp>
 #include <uhd/config.hpp>
 
 // constants coded into the fpga parameters

--- a/host/lib/usrp/e300/e300_network.cpp
+++ b/host/lib/usrp/e300/e300_network.cpp
@@ -39,6 +39,7 @@
 #include <boost/thread.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/make_shared.hpp>
+#include <boost/bind.hpp>
 
 #include <fstream>
 

--- a/host/lib/usrp/multi_usrp.cpp
+++ b/host/lib/usrp/multi_usrp.cpp
@@ -32,6 +32,7 @@
 #include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/bind.hpp>
 #include <algorithm>
 #include <cmath>
 

--- a/host/lib/usrp/usrp1/soft_time_ctrl.cpp
+++ b/host/lib/usrp/usrp1/soft_time_ctrl.cpp
@@ -20,6 +20,7 @@
 #include <boost/make_shared.hpp>
 #include <boost/thread/condition_variable.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/bind.hpp>
 #include <iostream>
 
 using namespace uhd;

--- a/host/lib/usrp/usrp1/usrp1_impl.cpp
+++ b/host/lib/usrp/usrp1/usrp1_impl.cpp
@@ -30,6 +30,7 @@
 #include <boost/thread/thread.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/math/special_functions/round.hpp>
+#include <boost/bind.hpp>
 #include <cstdio>
 
 using namespace uhd;

--- a/host/lib/usrp_clock/octoclock/octoclock_impl.cpp
+++ b/host/lib/usrp_clock/octoclock/octoclock_impl.cpp
@@ -24,6 +24,7 @@
 #include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind.hpp>
 
 #include <uhd/device.hpp>
 #include <uhd/exception.hpp>

--- a/host/lib/utils/ihex.cpp
+++ b/host/lib/utils/ihex.cpp
@@ -19,6 +19,7 @@
 #include <uhd/exception.hpp>
 #include <boost/format.hpp>
 #include <boost/make_shared.hpp>
+#include <boost/bind.hpp>
 #include <sstream>
 #include <fstream>
 

--- a/host/lib/utils/tasks.cpp
+++ b/host/lib/utils/tasks.cpp
@@ -20,6 +20,7 @@
 #include <uhd/utils/msg.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/barrier.hpp>
+#include <boost/bind.hpp>
 #include <exception>
 #include <iostream>
 #include <vector>

--- a/host/utils/uhd_cal_rx_iq_balance.cpp
+++ b/host/utils/uhd_cal_rx_iq_balance.cpp
@@ -26,6 +26,7 @@
 #include <boost/format.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/math/special_functions/round.hpp>
+#include <boost/bind.hpp>
 #include <iostream>
 #include <complex>
 #include <cmath>

--- a/host/utils/uhd_cal_tx_dc_offset.cpp
+++ b/host/utils/uhd_cal_tx_dc_offset.cpp
@@ -26,6 +26,7 @@
 #include <boost/format.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/math/special_functions/round.hpp>
+#include <boost/bind.hpp>
 #include <iostream>
 #include <complex>
 #include <ctime>

--- a/host/utils/uhd_cal_tx_iq_balance.cpp
+++ b/host/utils/uhd_cal_tx_iq_balance.cpp
@@ -21,6 +21,7 @@
 #include <boost/program_options.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/math/special_functions/round.hpp>
+#include <boost/bind.hpp>
 #include <iostream>
 #include <complex>
 #include <ctime>


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
Boost fixes for UHD-3.9.LTS branch.  Build of UHD-3.9.LTS branch fails when boost libs > 1.72.0.  This PR contains back-ports of similar commits from UHD-3.15.LTS branch.

## Which devices/areas does this affect?
Build of UHD.

## Testing Done
Built on up-to-date Arch Linux, Ubuntu 18.04, 20.04 distros.  Build with boost libs 1.75, 1.72, 1.71.
Tested RF TRX functionality and reliability with USRP x300, B205mini and B210.

## Checklist
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes, and all previous tests pass.
