### PR TITLE
rpclib: Remove -Wtype-limits warning for ARM builds.

### DIFF
--- a/host/lib/deps/rpclib/include/rpc/msgpack/adaptor/int.hpp
+++ b/host/lib/deps/rpclib/include/rpc/msgpack/adaptor/int.hpp
@@ -77,7 +77,7 @@ namespace detail {
 
     template <>
     struct object_char_sign<true> {
-        static inline void make(clmdep_msgpack::object& o, char v) {
+        static inline void make(clmdep_msgpack::object& o, signed char v) {
             if (v < 0) {
                 o.type = clmdep_msgpack::type::NEGATIVE_INTEGER;
                 o.via.i64 = v;


### PR DESCRIPTION
Signed-off-by: Ron Economos <w6rz@comcast.net>

# Pull Request Details
Removes these gcc warnings:
warning: comparison is always false due to limited range of data type [-Wtype-limits]

## Description
Change parameter that gets tested for < 0 to signed char.
On ARM, char defaults to unsigned.

## Which devices/areas does this affect?
Build on ARM processors.

## Testing Done
Built UHD on Ubuntu 18.04 for armv7.

## Checklist
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
