### PR TITLE
uhd: LO distribution functionality

### DIFF
--- a/host/include/uhd/usrp/multi_usrp.hpp
+++ b/host/include/uhd/usrp/multi_usrp.hpp
@@ -745,6 +745,22 @@ public:
     virtual std::vector<std::string> get_rx_lo_sources(
         const std::string& name = ALL_LOS, size_t chan = 0) = 0;
 
+    /*! Set whether the RX LO splitter output is active
+     *
+     * For USRPs that support distributable LOs, this function
+     * configures if the distributor outputs are active or not.
+     *
+     * \param enabled if true then set the output active
+     * \param name the name of the LO stage to update
+     * \param output the output to update (e.g., LO_OUT_0, LO_OUT_1, ...)
+     * \param chan the channel index 0 to N-1 for the source channel
+     * \throws uhd::runtime_error if LO exporting is not enabled
+     */
+    virtual void set_rx_lo_distribution(bool enabled,
+        const std::string& name,
+        const std::string& output,
+        size_t chan = 0) = 0;
+
     /*! Set whether the LO used by the device is exported
      *
      * For USRPs that support exportable LOs, this function
@@ -868,6 +884,22 @@ public:
      */
     virtual std::vector<std::string> get_tx_lo_sources(
         const std::string& name = ALL_LOS, const size_t chan = 0) = 0;
+
+    /*! Set whether the TX LO splitter output is active
+     *
+     * For USRPs that support distributable LOs, this function
+     * configures if the distributor outputs are active or not.
+     *
+     * \param enabled if true then set the output active
+     * \param name the name of the LO stage to update
+     * \param output the output to update (e.g., LO_OUT_0, LO_OUT_1, ...)
+     * \param chan the channel index 0 to N-1 for the source channel
+     * \throws uhd::runtime_error if LO exporting is not enabled
+     */
+    virtual void set_tx_lo_distribution(bool enabled,
+        const std::string& name,
+        const std::string& output,
+        size_t chan = 0) = 0;
 
     /*! Set whether the TX LO used by the device is exported
      *

--- a/host/lib/usrp/multi_usrp.cpp
+++ b/host/lib/usrp/multi_usrp.cpp
@@ -1271,6 +1271,25 @@ public:
         }
     }
 
+    void set_rx_lo_distribution(
+        bool enabled, const std::string& name, const std::string& output, size_t chan = 0)
+    {
+        if (_tree->exists(rx_rf_fe_root(chan) / "los")) {
+            if (_tree->exists(rx_rf_fe_root(chan) / "los" / name / "lo_distribution")) {
+                _tree
+                    ->access<bool>(rx_rf_fe_root(chan) / "los" / name / "lo_distribution"
+                                   / output / "export")
+                    .set(enabled);
+            } else {
+                throw uhd::runtime_error("This device does not support manual "
+                                         "configuration of LO distribution");
+            }
+        } else {
+            throw uhd::runtime_error(
+                "This device does not support manual configuration of LOs");
+        }
+    }
+
     void set_rx_lo_export_enabled(
         bool enabled, const std::string& name = ALL_LOS, size_t chan = 0)
     {
@@ -1487,6 +1506,25 @@ public:
             // If the daughterboard doesn't expose its LO(s) then it can only
             // be internal
             return std::vector<std::string>(1, "internal");
+        }
+    }
+
+    void set_tx_lo_distribution(
+        bool enabled, const std::string& name, const std::string& output, size_t chan = 0)
+    {
+        if (_tree->exists(tx_rf_fe_root(chan) / "los")) {
+            if (_tree->exists(tx_rf_fe_root(chan) / "los" / name / "lo_distribution")) {
+                _tree
+                    ->access<bool>(tx_rf_fe_root(chan) / "los" / name / "lo_distribution"
+                                   / output / "export")
+                    .set(enabled);
+            } else {
+                throw uhd::runtime_error("This device does not support manual "
+                                         "configuration of LO distribution");
+            }
+        } else {
+            throw uhd::runtime_error(
+                "This device does not support manual configuration of LOs");
         }
     }
 


### PR DESCRIPTION
This patch adds functionality to configure N321 LO distribution (enabling/disabling distribution output ports). I've noticed that the lack of such functionality has motivated a similar patch in https://github.com/daniestevez/uhd/tree/lo_sharing. Thus, it seems like having this functionality in the upstream repository could be of interest to others too.

If this patch is accepted, it would make sense to update also the documentation https://kb.ettus.com/USRP_N320/N321_LO_Distribution#UHD_LO_Distribution_Commands.