### PR TITLE
Fix uhd as cmake subproject

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -18,7 +18,7 @@ project(UHD CXX C)
 enable_testing()
 
 #make sure our local CMake Modules path comes first
-list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
+list(INSERT CMAKE_MODULE_PATH 0 ${UHD_SOURCE_DIR}/cmake/Modules)
 
 ########################################################################
 # UHD Dependency Minimum Versions
@@ -171,8 +171,8 @@ endif(DEFINED UHD_IMAGES_DIR_WINREG_KEY)
 ########################################################################
 # Local Include Dir
 ########################################################################
-include_directories(${CMAKE_BINARY_DIR}/include)
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${UHD_BINARY_DIR}/include)
+include_directories(${UHD_SOURCE_DIR}/include)
 
 ########################################################################
 # Static Lib Configuration
@@ -250,7 +250,7 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" OR
 endif()
 
 if(MSVC)
-    include_directories(${CMAKE_SOURCE_DIR}/cmake/msvc)
+    include_directories(${UHD_SOURCE_DIR}/cmake/msvc)
     add_definitions( #stop all kinds of compatibility warnings
         -DWIN32_LEAN_AND_MEAN
         -DVC_EXTRALEAN
@@ -339,7 +339,7 @@ PYTHON_CHECK_MODULE(
 # Create Uninstall Target
 ########################################################################
 configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in
+    ${UHD_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
 @ONLY)
 
@@ -376,7 +376,7 @@ LIBUHD_REGISTER_COMPONENT("Tests" ENABLE_TESTS ON "ENABLE_LIBUHD" OFF OFF)
 ########################################################################
 set(HAS_FPGA_SUBMODULE FALSE)
 execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import os; print(os.path.abspath(os.path.join('${CMAKE_SOURCE_DIR}', '..', 'fpga-src')))"
+    COMMAND ${PYTHON_EXECUTABLE} -c "import os; print(os.path.abspath(os.path.join('${UHD_SOURCE_DIR}', '..', 'fpga-src')))"
     OUTPUT_VARIABLE FPGA_SUBMODULE_DIR
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -472,20 +472,20 @@ else()
 endif(ENABLE_RFNOC)
 
 configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/Modules/UHDConfigVersion.cmake.in
-    ${CMAKE_BINARY_DIR}/cmake/Modules/UHDConfigVersion.cmake
+    ${UHD_SOURCE_DIR}/cmake/Modules/UHDConfigVersion.cmake.in
+    ${UHD_BINARY_DIR}/cmake/Modules/UHDConfigVersion.cmake
     @ONLY
 )
 configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/Modules/UHDConfig.cmake.in
-    ${CMAKE_BINARY_DIR}/cmake/Modules/UHDConfig.cmake
+    ${UHD_SOURCE_DIR}/cmake/Modules/UHDConfig.cmake.in
+    ${UHD_BINARY_DIR}/cmake/Modules/UHDConfig.cmake
     @ONLY
 )
 
 set(uhd_cmake_scripts
-    ${CMAKE_BINARY_DIR}/cmake/Modules/UHDConfig.cmake
-    ${CMAKE_BINARY_DIR}/cmake/Modules/UHDConfigVersion.cmake
-    ${CMAKE_SOURCE_DIR}/cmake/Modules/UHDBoost.cmake
+    ${UHD_BINARY_DIR}/cmake/Modules/UHDConfig.cmake
+    ${UHD_BINARY_DIR}/cmake/Modules/UHDConfigVersion.cmake
+    ${UHD_SOURCE_DIR}/cmake/Modules/UHDBoost.cmake
 )
 
 UHD_INSTALL(

--- a/host/cmake/Modules/CodeCoverage.cmake
+++ b/host/cmake/Modules/CodeCoverage.cmake
@@ -71,7 +71,7 @@
 find_program( GCOV_PATH gcov )
 find_program( LCOV_PATH lcov )
 find_program( GENHTML_PATH genhtml )
-find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
+find_program( GCOVR_PATH gcovr PATHS ${UHD_SOURCE_DIR}/tests)
 
 if(NOT GCOV_PATH)
 	message(FATAL_ERROR "gcov not found! Aborting...")
@@ -130,7 +130,7 @@ function(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 		message(FATAL_ERROR "genhtml not found! Aborting...")
 	endif() # NOT GENHTML_PATH
 
-	set(coverage_info "${CMAKE_BINARY_DIR}/${_outputname}.info")
+	set(coverage_info "${UHD_BINARY_DIR}/${_outputname}.info")
 	set(coverage_cleaned "${coverage_info}.cleaned")
 
 	separate_arguments(test_command UNIX_COMMAND "${_testrunner}")
@@ -150,7 +150,7 @@ function(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 		COMMAND ${GENHTML_PATH} -o ${_outputname} ${coverage_cleaned}
 		COMMAND ${CMAKE_COMMAND} -E remove ${coverage_info} ${coverage_cleaned}
 
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		WORKING_DIRECTORY ${UHD_BINARY_DIR}
 		COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
 	)
 
@@ -183,8 +183,8 @@ function(SETUP_TARGET_FOR_COVERAGE_COBERTURA _targetname _testrunner _outputname
 		${_testrunner} ${ARGV3}
 
 		# Running gcovr
-		COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR} -e '${CMAKE_SOURCE_DIR}/tests/'  -o ${_outputname}.xml
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		COMMAND ${GCOVR_PATH} -x -r ${UHD_SOURCE_DIR} -e '${UHD_SOURCE_DIR}/tests/'  -o ${_outputname}.xml
+		WORKING_DIRECTORY ${UHD_BINARY_DIR}
 		COMMENT "Running gcovr to produce Cobertura code coverage report."
 	)
 

--- a/host/cmake/Modules/UHDPackage.cmake
+++ b/host/cmake/Modules/UHDPackage.cmake
@@ -106,8 +106,8 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Ettus Research - USRP Hardware Driver")
 set(CPACK_PACKAGE_VENDOR              "Ettus Research (National Instruments)")
 set(CPACK_PACKAGE_CONTACT             "Ettus Research <support@ettus.com>")
 set(CPACK_PACKAGE_VERSION "${UHD_VERSION}")
-set(CPACK_RESOURCE_FILE_WELCOME ${CMAKE_SOURCE_DIR}/README.md)
-set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE)
+set(CPACK_RESOURCE_FILE_WELCOME ${UHD_SOURCE_DIR}/README.md)
+set(CPACK_RESOURCE_FILE_LICENSE ${UHD_SOURCE_DIR}/LICENSE)
 
 ########################################################################
 # Setup CPack Source
@@ -161,16 +161,16 @@ set(CPACK_COMPONENTS_ALL libraries pythonapi headers utilities examples manual d
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-all-dev, python3-requests")
 set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "python3, python3-tk")
 foreach(filename preinst postinst prerm postrm)
-    list(APPEND CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA ${CMAKE_BINARY_DIR}/debian/${filename})
-    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/debian)
+    list(APPEND CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA ${UHD_BINARY_DIR}/debian/${filename})
+    file(MAKE_DIRECTORY ${UHD_BINARY_DIR}/debian)
     configure_file(
-        ${CMAKE_SOURCE_DIR}/cmake/debian/${filename}.in
-        ${CMAKE_BINARY_DIR}/debian/${filename}
+        ${UHD_SOURCE_DIR}/cmake/debian/${filename}.in
+        ${UHD_BINARY_DIR}/debian/${filename}
     @ONLY)
 endforeach(filename)
 configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/debian/watch
-    ${CMAKE_BINARY_DIR}/debian/watch
+    ${UHD_SOURCE_DIR}/cmake/debian/watch
+    ${UHD_BINARY_DIR}/debian/watch
 @ONLY)
 
 ########################################################################
@@ -181,11 +181,11 @@ set(CPACK_RPM_PACKAGE_REQUIRES "boost-devel, python3-requests")
 set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/share/man;/usr/share/man/man1;/usr/lib64/pkgconfig;/usr/lib64/cmake;/usr/lib64/python2.7;/usr/lib64/python2.7/site-packages")
 foreach(filename post_install post_uninstall pre_install pre_uninstall)
     string(TOUPPER ${filename} filename_upper)
-    list(APPEND CPACK_RPM_${filename_upper}_SCRIPT_FILE ${CMAKE_BINARY_DIR}/redhat/${filename})
-    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/redhat)
+    list(APPEND CPACK_RPM_${filename_upper}_SCRIPT_FILE ${UHD_BINARY_DIR}/redhat/${filename})
+    file(MAKE_DIRECTORY ${UHD_BINARY_DIR}/redhat)
     configure_file(
-        ${CMAKE_SOURCE_DIR}/cmake/redhat/${filename}.in
-        ${CMAKE_BINARY_DIR}/redhat/${filename}
+        ${UHD_SOURCE_DIR}/cmake/redhat/${filename}.in
+        ${UHD_BINARY_DIR}/redhat/${filename}
     @ONLY)
 endforeach(filename)
 

--- a/host/cmake/Modules/UHDUnitTest.cmake
+++ b/host/cmake/Modules/UHDUnitTest.cmake
@@ -20,13 +20,13 @@ function(UHD_ADD_TEST test_name)
         #directory itself.
         if(WIN32)
             set(UHD_TEST_LIBRARY_DIRS
-                "${CMAKE_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE}"
+                "${UHD_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE}"
                 "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}"
                 "${Boost_LIBRARY_DIRS}"
             )
         else()
             set(UHD_TEST_LIBRARY_DIRS
-                "${CMAKE_BINARY_DIR}/lib"
+                "${UHD_BINARY_DIR}/lib"
                 "${CMAKE_CURRENT_BINARY_DIR}"
             )
             if(NOT APPLE)
@@ -53,7 +53,7 @@ function(UHD_ADD_TEST test_name)
 
         #replace list separator with the path separator
         string(REPLACE ";" ":" libpath "${libpath}")
-        list(APPEND environs "PATH=\"${binpath}\"" "${LD_PATH_VAR}=\"${libpath}\"" "UHD_RFNOC_DIR=\"${CMAKE_SOURCE_DIR}/include/uhd/rfnoc\"")
+        list(APPEND environs "PATH=\"${binpath}\"" "${LD_PATH_VAR}=\"${libpath}\"" "UHD_RFNOC_DIR=\"${UHD_SOURCE_DIR}/include/uhd/rfnoc\"")
 
         #generate a bat file that sets the environment and runs the test
         if (CMAKE_CROSSCOMPILING)
@@ -85,7 +85,7 @@ function(UHD_ADD_TEST test_name)
 
         #replace list separator with the path separator (escaped)
         string(REPLACE ";" "\\;" libpath "${libpath}")
-        list(APPEND environs "PATH=${libpath}" "UHD_RFNOC_DIR=${CMAKE_SOURCE_DIR}/include/uhd/rfnoc")
+        list(APPEND environs "PATH=${libpath}" "UHD_RFNOC_DIR=${UHD_SOURCE_DIR}/include/uhd/rfnoc")
 
         #generate a bat file that sets the environment and runs the test
         set(bat_file ${CMAKE_CURRENT_BINARY_DIR}/${test_name}_test.bat)

--- a/host/cmake/Modules/UHDVersion.cmake
+++ b/host/cmake/Modules/UHDVersion.cmake
@@ -36,7 +36,7 @@ endif(NOT DEFINED UHD_VERSION_DEVEL)
 set(UHD_GIT_BRANCH "")
 if(GIT_FOUND)
     execute_process(
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY ${UHD_SOURCE_DIR}
         COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
         OUTPUT_VARIABLE _git_branch OUTPUT_STRIP_TRAILING_WHITESPACE
         RESULT_VARIABLE _git_branch_result
@@ -75,7 +75,7 @@ endif(DEFINED UHD_GIT_BRANCH_OVERRIDE)
 
 #grab the git ref id for the current head
 execute_process(
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    WORKING_DIRECTORY ${UHD_SOURCE_DIR}
     COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=8 --long
     OUTPUT_VARIABLE _git_describe OUTPUT_STRIP_TRAILING_WHITESPACE
     RESULT_VARIABLE _git_describe_result
@@ -85,7 +85,7 @@ execute_process(
 if(_git_describe_result EQUAL 0)
     if(NOT UHD_GIT_COUNT)
         execute_process(
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            WORKING_DIRECTORY ${UHD_SOURCE_DIR}
             COMMAND ${PYTHON_EXECUTABLE} -c "
 try:
     print('${_git_describe}'.split('-')[-2])
@@ -97,7 +97,7 @@ except IndexError:
     endif()
     if(NOT UHD_GIT_HASH)
         execute_process(
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            WORKING_DIRECTORY ${UHD_SOURCE_DIR}
             COMMAND ${PYTHON_EXECUTABLE} -c "
 try:
     print('${_git_describe}'.split('-')[-1])
@@ -123,7 +123,7 @@ if(UHD_RELEASE_MODE)
 
     #Ignore UHD_GIT_COUNT in UHD_VERSION if the string 'release' is in UHD_RELEASE_MODE
     execute_process(
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY ${UHD_SOURCE_DIR}
         COMMAND ${PYTHON_EXECUTABLE} -c "print ('release' in '${UHD_RELEASE_MODE}') or ('rc' in '${UHD_RELEASE_MODE}')"
         OUTPUT_VARIABLE TRIM_UHD_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE
     )

--- a/host/docs/CMakeLists.txt
+++ b/host/docs/CMakeLists.txt
@@ -32,13 +32,13 @@ if(ENABLE_MANUAL)
     # First: Set up UHD manual only
     file(GLOB manual_sources "*.dox")
     set(DOXYGEN_DEPENDENCIES ${manual_sources})
-    set(DOXYGEN_INPUT_DIRS "${CMAKE_SOURCE_DIR}/docs ${CMAKE_CURRENT_BINARY_DIR}")
+    set(DOXYGEN_INPUT_DIRS "${UHD_SOURCE_DIR}/docs ${CMAKE_CURRENT_BINARY_DIR}")
     set(DOXYGEN_DEP_COMPONENT "manual")
     set(DOXYGEN_FPGA_MANUAL_REFERENCE "<a href=\"http://files.ettus.com/manual/md_fpga.html\">Part III: FPGA Manual</a>")
     set(DOXYGEN_STRIP_EXTRA "")
     set(DOXYGEN_EXCLUDE_DIRS "")
     if(NOT ENABLE_RFNOC)
-        set(DOXYGEN_EXCLUDE_DIRS "${DOXYGEN_EXCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/include/uhd/rfnoc")
+        set(DOXYGEN_EXCLUDE_DIRS "${DOXYGEN_EXCLUDE_DIRS} ${UHD_SOURCE_DIR}/include/uhd/rfnoc")
     endif(NOT ENABLE_RFNOC)
     # Now, check if we have the FPGA sources as well.
     # If so, pull them in:
@@ -70,14 +70,14 @@ endif(LIBUHDDEV_PKG)
 if(ENABLE_DOXYGEN)
     set(ENABLE_MANUAL_OR_DOXYGEN true)
     #make doxygen directory depend on the header files
-    file(GLOB_RECURSE header_files ${CMAKE_SOURCE_DIR}/include/*.hpp)
-    file(GLOB_RECURSE h_files ${CMAKE_SOURCE_DIR}/include/*.h)
+    file(GLOB_RECURSE header_files ${UHD_SOURCE_DIR}/include/*.hpp)
+    file(GLOB_RECURSE h_files ${UHD_SOURCE_DIR}/include/*.h)
     list(APPEND header_files ${h_files})
-    set(DOXYGEN_DEPENDENCIES ${DOXYGEN_DEPENDENCIES} ${header_files} "${CMAKE_SOURCE_DIR}/lib/rfnoc/nocscript/gen_basic_funcs.py")
+    set(DOXYGEN_DEPENDENCIES ${DOXYGEN_DEPENDENCIES} ${header_files} "${UHD_SOURCE_DIR}/lib/rfnoc/nocscript/gen_basic_funcs.py")
     if(ENABLE_DOXYGEN_FULL)
-        set(DOXYGEN_INPUT_DIRS "${DOXYGEN_INPUT_DIRS} ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/python")
+        set(DOXYGEN_INPUT_DIRS "${DOXYGEN_INPUT_DIRS} ${UHD_SOURCE_DIR}/include ${UHD_SOURCE_DIR}/lib ${UHD_SOURCE_DIR}/python")
     else(ENABLE_DOXYGEN_FULL)
-        set(DOXYGEN_INPUT_DIRS "${DOXYGEN_INPUT_DIRS} ${CMAKE_SOURCE_DIR}/include")
+        set(DOXYGEN_INPUT_DIRS "${DOXYGEN_INPUT_DIRS} ${UHD_SOURCE_DIR}/include")
     endif(ENABLE_DOXYGEN_FULL)
 
     set(DOXYGEN_DEP_COMPONENT "doxygen")
@@ -110,7 +110,7 @@ if(ENABLE_MANUAL_OR_DOXYGEN)
     @ONLY)
 
     #make doxygen directory depend on the header files
-    file(GLOB_RECURSE header_files ${CMAKE_SOURCE_DIR}/include/*.hpp)
+    file(GLOB_RECURSE header_files ${UHD_SOURCE_DIR}/include/*.hpp)
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR_DOXYGEN} DEPENDS ${DOXYGEN_DEPENDENCIES}
         COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile

--- a/host/docs/Doxyfile.in
+++ b/host/docs/Doxyfile.in
@@ -47,7 +47,7 @@ PROJECT_BRIEF          = "UHD and USRP Manual"
 # exceed 55 pixels and the maximum width should not exceed 200 pixels.
 # Doxygen will copy the logo to the output directory.
 
-PROJECT_LOGO           = @CMAKE_SOURCE_DIR@/docs/Ettus_Logo.png
+PROJECT_LOGO           = @UHD_SOURCE_DIR@/docs/Ettus_Logo.png
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.
@@ -132,7 +132,7 @@ FULL_PATH_NAMES        = YES
 # relative paths, which will be relative from the directory where doxygen is
 # started.
 
-STRIP_FROM_PATH        = @CMAKE_SOURCE_DIR@ @DOXYGEN_STRIP_EXTRA@
+STRIP_FROM_PATH        = @UHD_SOURCE_DIR@ @DOXYGEN_STRIP_EXTRA@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of
 # the path mentioned in the documentation of a class, which tells
@@ -141,7 +141,7 @@ STRIP_FROM_PATH        = @CMAKE_SOURCE_DIR@ @DOXYGEN_STRIP_EXTRA@
 # definition is used. Otherwise one should specify the include paths that
 # are normally passed to the compiler using the -I flag.
 
-STRIP_FROM_INC_PATH    = @CMAKE_SOURCE_DIR@/include
+STRIP_FROM_INC_PATH    = @UHD_SOURCE_DIR@/include
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter
 # (but less readable) file names. This can be useful if your file system
@@ -686,9 +686,9 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = @CMAKE_SOURCE_DIR@/include/uhd/transport/nirio \
-                         @CMAKE_SOURCE_DIR@/include/uhd/transport/nirio_zero_copy.hpp @DOXYGEN_EXCLUDE_DIRS@ \
-                         @CMAKE_SOURCE_DIR@/lib/deps
+EXCLUDE                = @UHD_SOURCE_DIR@/include/uhd/transport/nirio \
+                         @UHD_SOURCE_DIR@/include/uhd/transport/nirio_zero_copy.hpp @DOXYGEN_EXCLUDE_DIRS@ \
+                         @UHD_SOURCE_DIR@/lib/deps
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -736,7 +736,7 @@ EXAMPLE_RECURSIVE      = NO
 # directories that contain image that are included in the documentation (see
 # the \image command).
 
-IMAGE_PATH             = @CMAKE_SOURCE_DIR@/docs/res
+IMAGE_PATH             = @UHD_SOURCE_DIR@/docs/res
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program

--- a/host/lib/CMakeLists.txt
+++ b/host/lib/CMakeLists.txt
@@ -34,8 +34,8 @@ endmacro(LIBUHD_PYTHON_GEN_SOURCE)
 
 macro(INCLUDE_SUBDIRECTORY subdir)
     #insert the current directories on the front of the list
-    list(INSERT _cmake_source_dirs 0 ${CMAKE_CURRENT_SOURCE_DIR})
-    list(INSERT _cmake_binary_dirs 0 ${CMAKE_CURRENT_BINARY_DIR})
+    list(INSERT _UHD_SOURCE_DIRs 0 ${CMAKE_CURRENT_SOURCE_DIR})
+    list(INSERT _UHD_BINARY_DIRs 0 ${CMAKE_CURRENT_BINARY_DIR})
 
     #set the current directories to the names of the subdirs
     set(CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${subdir})
@@ -46,12 +46,12 @@ macro(INCLUDE_SUBDIRECTORY subdir)
     include(${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
 
     #reset the value of the current directories
-    list(GET _cmake_source_dirs 0 CMAKE_CURRENT_SOURCE_DIR)
-    list(GET _cmake_binary_dirs 0 CMAKE_CURRENT_BINARY_DIR)
+    list(GET _UHD_SOURCE_DIRs 0 CMAKE_CURRENT_SOURCE_DIR)
+    list(GET _UHD_BINARY_DIRs 0 CMAKE_CURRENT_BINARY_DIR)
 
     #pop the subdir names of the front of the list
-    list(REMOVE_AT _cmake_source_dirs 0)
-    list(REMOVE_AT _cmake_binary_dirs 0)
+    list(REMOVE_AT _UHD_SOURCE_DIRs 0)
+    list(REMOVE_AT _UHD_BINARY_DIRs 0)
 endmacro(INCLUDE_SUBDIRECTORY)
 
 ########################################################################
@@ -148,7 +148,7 @@ if(MSVC)
         if(IS_ABSOLUTE "${CUSTOM_RC_FILE}")
             set(UHD_RC_IN "${CUSTOM_RC_FILE}")
         else()
-            set(UHD_RC_IN "${CMAKE_BINARY_DIR}/${CUSTOM_RC_FILE}")
+            set(UHD_RC_IN "${UHD_BINARY_DIR}/${CUSTOM_RC_FILE}")
         endif(IS_ABSOLUTE "${CUSTOM_RC_FILE}")
         message(STATUS "")
         message(STATUS "Using custom RC template: ${UHD_RC_IN}")

--- a/host/lib/CMakeLists.txt
+++ b/host/lib/CMakeLists.txt
@@ -34,8 +34,8 @@ endmacro(LIBUHD_PYTHON_GEN_SOURCE)
 
 macro(INCLUDE_SUBDIRECTORY subdir)
     #insert the current directories on the front of the list
-    list(INSERT _UHD_SOURCE_DIRs 0 ${CMAKE_CURRENT_SOURCE_DIR})
-    list(INSERT _UHD_BINARY_DIRs 0 ${CMAKE_CURRENT_BINARY_DIR})
+    list(INSERT _cmake_source_dirs 0 ${CMAKE_CURRENT_SOURCE_DIR})
+    list(INSERT _cmake_binary_dirs 0 ${CMAKE_CURRENT_BINARY_DIR})
 
     #set the current directories to the names of the subdirs
     set(CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${subdir})
@@ -46,12 +46,12 @@ macro(INCLUDE_SUBDIRECTORY subdir)
     include(${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
 
     #reset the value of the current directories
-    list(GET _UHD_SOURCE_DIRs 0 CMAKE_CURRENT_SOURCE_DIR)
-    list(GET _UHD_BINARY_DIRs 0 CMAKE_CURRENT_BINARY_DIR)
+    list(GET _cmake_source_dirs 0 CMAKE_CURRENT_SOURCE_DIR)
+    list(GET _cmake_binary_dirs 0 CMAKE_CURRENT_BINARY_DIR)
 
     #pop the subdir names of the front of the list
-    list(REMOVE_AT _UHD_SOURCE_DIRs 0)
-    list(REMOVE_AT _UHD_BINARY_DIRs 0)
+    list(REMOVE_AT _cmake_source_dirs 0)
+    list(REMOVE_AT _cmake_binary_dirs 0)
 endmacro(INCLUDE_SUBDIRECTORY)
 
 ########################################################################

--- a/host/lib/rfnoc/nocscript/CMakeLists.txt
+++ b/host/lib/rfnoc/nocscript/CMakeLists.txt
@@ -15,7 +15,7 @@ LIBUHD_PYTHON_GEN_SOURCE(
 if(ENABLE_MANUAL)
     LIBUHD_PYTHON_GEN_SOURCE(
         ${CMAKE_CURRENT_SOURCE_DIR}/gen_basic_funcs.py
-        ${CMAKE_BINARY_DIR}/docs/nocscript_functions.dox
+        ${UHD_BINARY_DIR}/docs/nocscript_functions.dox
     )
 endif(ENABLE_MANUAL)
 

--- a/host/lib/transport/nirio/lvbitx/CMakeLists.txt
+++ b/host/lib/transport/nirio/lvbitx/CMakeLists.txt
@@ -12,7 +12,7 @@ macro(LIBUHD_LVBITX_GEN_SOURCE_AND_BITSTREAM lvbitx binfile)
         set( GEN_OPTIONS )
         message( STATUS "  Using ${lvbitx} for codegen" )
     else( ${binfile} STREQUAL "OFF" )
-        set( GEN_OPTIONS --merge-bin=${CMAKE_SOURCE_DIR}/../binaries/${binfile} --output-lvbitx-path=${CMAKE_SOURCE_DIR}/../binaries )
+        set( GEN_OPTIONS --merge-bin=${UHD_SOURCE_DIR}/../binaries/${binfile} --output-lvbitx-path=${UHD_SOURCE_DIR}/../binaries )
         message( STATUS "  Merging ${lvbitx} with ${binfile} for codegen" )
     endif( ${binfile} STREQUAL "OFF" )
 

--- a/host/python/CMakeLists.txt
+++ b/host/python/CMakeLists.txt
@@ -17,7 +17,7 @@ PYTHON_CHECK_MODULE(
 # Get include dirs
 include_directories(${PYTHON_INCLUDE_DIRS})
 set(PYBIND11_INCLUDE_DIR
-    "${CMAKE_SOURCE_DIR}/lib/deps/pybind11/include"
+    "${UHD_SOURCE_DIR}/lib/deps/pybind11/include"
     CACHE
     STRING
     "Location of PyBind11 includes"
@@ -47,7 +47,7 @@ else()
 endif(WIN32)
 target_include_directories(pyuhd PUBLIC
     ${PYTHON_NUMPY_INCLUDE_DIR}
-    ${CMAKE_SOURCE_DIR}/lib
+    ${UHD_SOURCE_DIR}/lib
     ${PYBIND11_INCLUDE_DIR}
 )
 

--- a/host/tests/CMakeLists.txt
+++ b/host/tests/CMakeLists.txt
@@ -85,7 +85,7 @@ if(ENABLE_C_API)
     )
 endif(ENABLE_C_API)
 
-include_directories("${CMAKE_SOURCE_DIR}/lib/include")
+include_directories("${UHD_SOURCE_DIR}/lib/include")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/common")
 
 #for each source: build an executable, register it as a test
@@ -133,15 +133,15 @@ if(ENABLE_DPDK)
     UHD_ADD_NONAPI_TEST(
         TARGET "dpdk_test.cpp"
         EXTRA_SOURCES
-        ${CMAKE_SOURCE_DIR}/lib/utils/config_parser.cpp
-        ${CMAKE_SOURCE_DIR}/lib/utils/paths.cpp
-        ${CMAKE_SOURCE_DIR}/lib/utils/pathslib.cpp
-        ${CMAKE_SOURCE_DIR}/lib/utils/prefs.cpp
-        ${CMAKE_SOURCE_DIR}/lib/transport/dpdk_zero_copy.cpp
+        ${UHD_SOURCE_DIR}/lib/utils/config_parser.cpp
+        ${UHD_SOURCE_DIR}/lib/utils/paths.cpp
+        ${UHD_SOURCE_DIR}/lib/utils/pathslib.cpp
+        ${UHD_SOURCE_DIR}/lib/utils/prefs.cpp
+        ${UHD_SOURCE_DIR}/lib/transport/dpdk_zero_copy.cpp
         INCLUDE_DIRS
         ${DPDK_INCLUDE_DIR}
-        ${CMAKE_BINARY_DIR}/lib/transport/
-        ${CMAKE_SOURCE_DIR}/lib/transport/
+        ${UHD_BINARY_DIR}/lib/transport/
+        ${UHD_SOURCE_DIR}/lib/transport/
         EXTRA_LIBS ${DPDK_LIBRARIES}
         NOAUTORUN # Don't register for auto-run, it requires special config
     )
@@ -150,36 +150,36 @@ ENDIF(ENABLE_DPDK)
 UHD_ADD_NONAPI_TEST(
     TARGET "nocscript_expr_test.cpp"
     EXTRA_SOURCES
-    "${CMAKE_SOURCE_DIR}/lib/rfnoc/nocscript/expression.cpp"
+    "${UHD_SOURCE_DIR}/lib/rfnoc/nocscript/expression.cpp"
     INCLUDE_DIRS
-    ${CMAKE_BINARY_DIR}/lib/rfnoc/nocscript/
-    ${CMAKE_SOURCE_DIR}/lib/rfnoc/nocscript/
+    ${UHD_BINARY_DIR}/lib/rfnoc/nocscript/
+    ${UHD_SOURCE_DIR}/lib/rfnoc/nocscript/
 )
 
 UHD_ADD_NONAPI_TEST(
     TARGET "nocscript_ftable_test.cpp"
     EXTRA_SOURCES
-    ${CMAKE_SOURCE_DIR}/lib/rfnoc/nocscript/function_table.cpp
-    ${CMAKE_SOURCE_DIR}/lib/rfnoc/nocscript/expression.cpp
+    ${UHD_SOURCE_DIR}/lib/rfnoc/nocscript/function_table.cpp
+    ${UHD_SOURCE_DIR}/lib/rfnoc/nocscript/expression.cpp
     INCLUDE_DIRS
-    ${CMAKE_BINARY_DIR}/lib/rfnoc/nocscript/
-    ${CMAKE_SOURCE_DIR}/lib/rfnoc/nocscript/
+    ${UHD_BINARY_DIR}/lib/rfnoc/nocscript/
+    ${UHD_SOURCE_DIR}/lib/rfnoc/nocscript/
 )
 
 UHD_ADD_NONAPI_TEST(
     TARGET "nocscript_parser_test.cpp"
     EXTRA_SOURCES
-    ${CMAKE_SOURCE_DIR}/lib/rfnoc/nocscript/parser.cpp
-    ${CMAKE_SOURCE_DIR}/lib/rfnoc/nocscript/function_table.cpp
-    ${CMAKE_SOURCE_DIR}/lib/rfnoc/nocscript/expression.cpp
+    ${UHD_SOURCE_DIR}/lib/rfnoc/nocscript/parser.cpp
+    ${UHD_SOURCE_DIR}/lib/rfnoc/nocscript/function_table.cpp
+    ${UHD_SOURCE_DIR}/lib/rfnoc/nocscript/expression.cpp
     INCLUDE_DIRS
-    ${CMAKE_BINARY_DIR}/lib/rfnoc/nocscript/
-    ${CMAKE_SOURCE_DIR}/lib/rfnoc/nocscript/
+    ${UHD_BINARY_DIR}/lib/rfnoc/nocscript/
+    ${UHD_SOURCE_DIR}/lib/rfnoc/nocscript/
 )
 
 UHD_ADD_NONAPI_TEST(
     TARGET "config_parser_test.cpp"
-    EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/lib/utils/config_parser.cpp
+    EXTRA_SOURCES ${UHD_SOURCE_DIR}/lib/utils/config_parser.cpp
 )
 
 # Careful: This is to satisfy the out-of-library build of paths.cpp. This is
@@ -189,14 +189,14 @@ set(UHD_LIB_DIR "lib")
 file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}" UHD_PKG_PATH)
 string(REPLACE "\\" "\\\\" UHD_PKG_PATH "${UHD_PKG_PATH}")
 set_source_files_properties(
-    ${CMAKE_SOURCE_DIR}/lib/utils/paths.cpp
+    ${UHD_SOURCE_DIR}/lib/utils/paths.cpp
     PROPERTIES COMPILE_DEFINITIONS
     "UHD_PKG_PATH=\"${UHD_PKG_PATH}\";UHD_LIB_DIR=\"${UHD_LIB_DIR}\""
 )
 UHD_ADD_NONAPI_TEST(
     TARGET "paths_test.cpp"
     EXTRA_SOURCES
-    ${CMAKE_SOURCE_DIR}/lib/utils/pathslib.cpp
+    ${UHD_SOURCE_DIR}/lib/utils/pathslib.cpp
 )
 
 ########################################################################

--- a/host/tests/common/CMakeLists.txt
+++ b/host/tests/common/CMakeLists.txt
@@ -7,9 +7,9 @@
 ########################################################################
 # Build uhd_test static lib
 ########################################################################
-include_directories("${CMAKE_SOURCE_DIR}/lib/include")
+include_directories("${UHD_SOURCE_DIR}/lib/include")
 add_library(uhd_test ${CMAKE_CURRENT_SOURCE_DIR}/mock_ctrl_iface_impl.cpp
                      ${CMAKE_CURRENT_SOURCE_DIR}/mock_zero_copy.cpp
-                     ${CMAKE_SOURCE_DIR}/lib/rfnoc/graph_impl.cpp
-                     ${CMAKE_SOURCE_DIR}/lib/rfnoc/async_msg_handler.cpp
+                     ${UHD_SOURCE_DIR}/lib/rfnoc/graph_impl.cpp
+                     ${UHD_SOURCE_DIR}/lib/rfnoc/async_msg_handler.cpp
 )

--- a/host/tests/devtest/CMakeLists.txt
+++ b/host/tests/devtest/CMakeLists.txt
@@ -28,7 +28,7 @@ macro(ADD_DEVTEST pattern filter devtype)
         "--devtest-pattern" "${pattern}"
         "--device-filter" "${filter}"
         "--build-type" "${CMAKE_BUILD_TYPE}"
-        "--build-dir" "${CMAKE_BINARY_DIR}"
+        "--build-dir" "${UHD_BINARY_DIR}"
         "--python-interp" "${RUNTIME_PYTHON_EXECUTABLE}"
         COMMENT "Running device test on all connected ${devtype} devices:"
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"


### PR DESCRIPTION
# Pull Request Details
For details please see issue 425
https://github.com/EttusResearch/uhd/issues/425

## Description
Add the possibility to use UHD as subproject of an existing project.

## Related Issue
Fixes #425

## Which devices/areas does this affect?
Add a new option to build UHD. 
It's a nice-to-have feature for people who prefer always building from source with exactly the same toolchain.

## Testing Done
I have built uhd both as subproject and as stand alone project

## Checklist
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
