### PR TITLE
n3xx: Add 'XQ' image as valid when using sfp0 time_source (fixes #434)

### DIFF
--- a/mpm/python/usrp_mpm/periph_manager/n3xx.py
+++ b/mpm/python/usrp_mpm/periph_manager/n3xx.py
@@ -671,7 +671,7 @@ class n3xx(ZynqComponents, PeriphManagerBase):
                     time_source)
                 self.log.error(error_msg)
                 raise RuntimeError(error_msg)
-            sfp_time_source_images = ('WX',)
+            sfp_time_source_images = ('WX', 'XQ')
             if self.updateable_components['fpga']['type'] not in sfp_time_source_images:
                 self.log.error("{} time source requires FPGA types {}" \
                                .format(time_source, sfp_time_source_images))


### PR DESCRIPTION
See #434.