### PR TITLE
Fix compilation with Boost 1.76, fix modulation with negative frequency offsets

### DIFF
--- a/host/lib/usrp/usrp2/usrp2_impl.cpp
+++ b/host/lib/usrp/usrp2/usrp2_impl.cpp
@@ -20,6 +20,7 @@
 #include <boost/format.hpp>
 #include <boost/thread.hpp>
 #include <functional>
+#include <cmath>
 
 using namespace uhd;
 using namespace uhd::usrp;
@@ -917,22 +918,21 @@ double usrp2_impl::set_tx_dsp_freq(const std::string& mb, const double freq_)
     const double tick_rate = _tree->access<double>("/mboards/" + mb + "/tick_rate").get();
 
     // calculate the DAC shift (multiples of rate)
-    const int sign         = boost::math::sign(new_freq);
-    const int zone         = std::min(boost::math::iround(new_freq / tick_rate), 2);
-    const double dac_shift = sign * zone * tick_rate;
+    const int zone         = std::max(std::min(std::lround(new_freq / tick_rate), 2), -2);
+    const double dac_shift = zone * tick_rate;
     new_freq -= dac_shift; // update FPGA DSP target freq
     UHD_LOG_TRACE("USRP2",
         "DSP Tuning: Requested " + std::to_string(freq_ / 1e6)
             + " MHz, Using "
               "Nyquist zone "
-            + std::to_string(sign * zone)
+            + std::to_string(zone)
             + ", leftover DSP tuning: " + std::to_string(new_freq / 1e6) + " MHz.");
 
     // set the DAC shift (modulation mode)
     if (zone == 0) {
         _mbc[mb].codec->set_tx_mod_mode(0); // no shift
     } else {
-        _mbc[mb].codec->set_tx_mod_mode(sign * 4 / zone); // DAC interp = 4
+        _mbc[mb].codec->set_tx_mod_mode(4 / zone); // DAC interp = 4
     }
 
     return _mbc[mb].tx_dsp->set_freq(new_freq) + dac_shift; // actual freq

--- a/host/lib/usrp/usrp2/usrp2_impl.cpp
+++ b/host/lib/usrp/usrp2/usrp2_impl.cpp
@@ -918,7 +918,7 @@ double usrp2_impl::set_tx_dsp_freq(const std::string& mb, const double freq_)
     const double tick_rate = _tree->access<double>("/mboards/" + mb + "/tick_rate").get();
 
     // calculate the DAC shift (multiples of rate)
-    const int zone         = std::max(std::min(std::lround(new_freq / tick_rate), 2), -2);
+    const int zone         = std::max(std::min<int>(std::lround(new_freq / tick_rate), 2), -2);
     const double dac_shift = zone * tick_rate;
     new_freq -= dac_shift; // update FPGA DSP target freq
     UHD_LOG_TRACE("USRP2",


### PR DESCRIPTION
# Pull Request Details
1. Boost 1.76 requires explicit includes for functionality from boost::math.

2. Frequency calculation for negative frequencies where `abs(freq)  > rate/2` is believed to be wrong:
   - `int zone` is not clamped for negative values
   - the sign is applied twice for negative values

 No change in set values for positive frequencies, or for negative frequencies where `zone == 0`.

## Description
Fixes compilation with Boost 1.76 (replace boost::math special functions with equivalent from std::)
Likely fixes frequency calculation for negative frequencies, i.e. Nyquist zone <= -1.


## Related Issue
#437, #438 

## Which devices/areas does this affect?
USRP 2

## Testing Done
Compiles

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
