### PR TITLE
lib/include/uhdlib/utils/rpc.hpp was missing an include file reference to "thread"

### DIFF
--- a/host/lib/include/uhdlib/utils/rpc.hpp
+++ b/host/lib/include/uhdlib/utils/rpc.hpp
@@ -13,6 +13,7 @@
 #include <rpc/rpc_error.h>
 #include <boost/format.hpp>
 #include <memory>
+#include <thread>
 
 namespace {
 


### PR DESCRIPTION
for the C++ standard "thread" header.  This caused Fedora 34/gcc 11.0.1
to flag this as an error, as it could not find the sleep method.

Fixed with "#include<thread>

# Pull Request Details
GCC 11.0.1 complained of a missing <thread> header when it couldn't find std::sleep 



## Description
Libuhd v4.0.0.0 will not build on Fedora 34 with gcc 11.0.1 otherwise. 


## Related Issue
No related issues

## Which devices/areas does this affect?
Affects libuhd across all devices.

## Testing Done
Added the include, built the library. Lit up a radio. 

## Checklist


- [ X] I have read the CONTRIBUTING document.
- [ X] My code follows the code style of this project. See CODING.md.
- [ X] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes, and all previous tests pass.
