### PR TITLE
Fix DBSRX support on USRP1

### DIFF
--- a/host/lib/usrp/dboard/db_dbsrx.cpp
+++ b/host/lib/usrp/dboard/db_dbsrx.cpp
@@ -272,7 +272,10 @@ double dbsrx::set_lo_freq(double target_freq)
     std::vector<double> clock_rates =
         this->get_iface()->get_clock_rates(dboard_iface::UNIT_RX);
     const double max_clock_rate = uhd::sorted(clock_rates).back();
-    for (auto ref_clock : uhd::reversed(uhd::sorted(clock_rates))) {
+    std::vector<double> clock_rates_vec = uhd::reversed(uhd::sorted(clock_rates));
+    for (int i = 0; i < clock_rates_vec.size(); i++) {
+        ref_clock = clock_rates_vec[i];
+
         // USRP1 feeds the DBSRX clock from a FPGA GPIO line.
         // make sure that this clock does not exceed rate limit.
         if (this->get_iface()->get_special_props().soft_clock_divider) {
@@ -298,7 +301,7 @@ double dbsrx::set_lo_freq(double target_freq)
             continue;
 
         // choose R
-        for (auto r = 0; r <= 6; r += 1) {
+        for (r = 0; r <= 6; r += 1) {
             // compute divider from setting
             R = 1 << (r + 1);
             UHD_LOGGER_TRACE("DBSRX") << boost::format("DBSRX R:%d\n") % R;


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->
This fixes the DBSRX daughterboard not being initialized properly on older USRPs.

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
An USRP1 with the first generation DBSRX would not work on newer libuhd versions, despite working just fine on an older system.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
https://github.com/EttusResearch/uhd/issues/394

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->
Not really sure, probably only the USRP1

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested in the setup stated above, resulting the DBSRX board working as expected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X ] I have read the CONTRIBUTING document.
- [ X] My code follows the code style of this project. See CODING.md.
- [ X] I have updated the documentation accordingly. (doesn't apply)
- [ X] I have added tests to cover my changes, and all previous tests pass. (doesn't apply)
