### PR TITLE
remove spurious template from property destructor

### DIFF
--- a/host/include/uhd/property_tree.hpp
+++ b/host/include/uhd/property_tree.hpp
@@ -73,7 +73,7 @@ public:
     typedef boost::function<T(void)> publisher_type;
     typedef boost::function<T(const T&)> coercer_type;
 
-    virtual ~property<T>(void) = 0;
+    virtual ~property(void) = 0;
 
     /*!
      * Register a coercer into the property.

--- a/host/include/uhd/property_tree.ipp
+++ b/host/include/uhd/property_tree.ipp
@@ -30,7 +30,7 @@ public:
         }
     }
 
-    ~property_impl<T>(void)
+    ~property_impl(void)
     {
         /* NOP */
     }


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->
C++ syntax cleanup.

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
g++ 11 is now more picky about syntax, and flags errors rather
than ignores use of template-id for a destructor.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Needed for building on Debian bookworm (current unstable/testing).

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
