### PR TITLE
image builder: Add support for reading number of ports from grc file

### DIFF
--- a/host/python/uhd/imgbuilder/image_builder.py
+++ b/host/python/uhd/imgbuilder/image_builder.py
@@ -222,7 +222,7 @@ class ImageBuilderConfig:
                 setattr(desc, "parameters", {})
             if "parameters" not in block:
                 block["parameters"] = OrderedDict()
-            for key in block["parameters"].keys():
+            for key in list(block["parameters"].keys()):
                 if key not in desc.parameters:
                     logging.error("Unknown parameter %s for block %s", key, name)
                     del block["parameters"][key]

--- a/host/python/uhd/imgbuilder/image_builder.py
+++ b/host/python/uhd/imgbuilder/image_builder.py
@@ -537,6 +537,10 @@ def convert_to_image_config(grc, grc_config_path):
         result["noc_blocks"][block["name"]] = {
             "block_desc": block["parameters"]["desc"]
         }
+        if "nports" in block["parameters"]:
+            result["noc_blocks"][block["name"]]["parameters"] = {
+                "NUM_PORTS": block["parameters"]["nports"]
+            }
 
     device_clocks = {
         port["id"]: port for port in grc_blocks[device['id']]["outputs"]


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
For some blocks GNU Radio allows to specify the number of ports (`nports`).
If this number doesn't match the number of ports (`NUM_PORTS`) given in the yaml-description file of a block,
image builder fails with "Unresolved connection(s)" because some block ports are missing.

Read the number of ports from grc file to override default value from yaml block description.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
