### PR TITLE
host: fix build with DPDK v21.11 LTS

### DIFF
--- a/host/lib/transport/udp_dpdk_link.cpp
+++ b/host/lib/transport/udp_dpdk_link.cpp
@@ -175,8 +175,13 @@ void udp_dpdk_link::release_send_buff(frame_buff::uptr buff)
         // Fill in L2 header
         auto local_mac           = _port->get_mac_addr();
         struct rte_ether_hdr* l2_hdr = rte_pktmbuf_mtod(mbuf, struct rte_ether_hdr*);
+#if RTE_VER_YEAR > 21 || (RTE_VER_YEAR == 21 && RTE_VER_MONTH == 11)
+        rte_ether_addr_copy(&_remote_mac, &l2_hdr->dst_addr);
+        rte_ether_addr_copy(&local_mac, &l2_hdr->src_addr);
+#else
         rte_ether_addr_copy(&_remote_mac, &l2_hdr->d_addr);
         rte_ether_addr_copy(&local_mac, &l2_hdr->s_addr);
+#endif
         l2_hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
         // Fill in L3 and L4 headers
         dpdk::fill_rte_udp_hdr(mbuf,

--- a/host/lib/transport/uhd-dpdk/dpdk_io_service.cpp
+++ b/host/lib/transport/uhd-dpdk/dpdk_io_service.cpp
@@ -629,8 +629,13 @@ int dpdk_io_service::_send_arp_request(
     hdr       = rte_pktmbuf_mtod(mbuf, struct rte_ether_hdr*);
     arp_frame = (struct rte_arp_hdr*)&hdr[1];
 
+#if RTE_VER_YEAR > 21 || (RTE_VER_YEAR == 21 && RTE_VER_MONTH == 11)
+    memset(hdr->dst_addr.addr_bytes, 0xFF, RTE_ETHER_ADDR_LEN);
+    hdr->src_addr   = port->get_mac_addr();
+#else
     memset(hdr->d_addr.addr_bytes, 0xFF, RTE_ETHER_ADDR_LEN);
     hdr->s_addr     = port->get_mac_addr();
+#endif
     hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
 
     arp_frame->arp_hardware          = rte_cpu_to_be_16(RTE_ARP_HRD_ETHER);


### PR DESCRIPTION
# Pull Request Details
Some APIs were changed with the latest DPDK LTS release,
add some ifdefs to fix the build.

## Related Issue
Fixes #547

## Which devices/areas does this affect?
DPDK component

## Testing Done
Build-tested only, with DPDK 20.11 and 21.11

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
