### PR TITLE
fix building with split tinfo

### DIFF
--- a/host/examples/CMakeLists.txt
+++ b/host/examples/CMakeLists.txt
@@ -51,6 +51,7 @@ endforeach(example_source)
 ########################################################################
 # ASCII Art DFT - requires curses, so this part is optional
 ########################################################################
+set(CURSES_NEED_NCURSES 1)
 find_package(Curses)
 
 if(CURSES_FOUND)

--- a/host/utils/latency/CMakeLists.txt
+++ b/host/utils/latency/CMakeLists.txt
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+set(CURSES_NEED_NCURSES 1)
 find_package(Curses)
 
 if(CURSES_FOUND)


### PR DESCRIPTION
When building on a distro which has tinfo split into a separate library from ncurses, building fails.  Previously this was handled by a distro patch, but after much troubleshooting this solution appears to be the most correct.  During the troubleshooting it was initially blamed on a cmake issue, but cmake upstream basically says that it's working as intended and suggested this fix.

Unless upstream cmake changes course and accept this as their bug, this small fix should benefit Gentoo (and I'm not sure who else) at the expense of adding one line of code which causes FindCurses to properly detect split tinfo.

https://gitlab.kitware.com/cmake/cmake/-/issues/23236