### PR TITLE
mpm: fix ref_locked sensor on n320

### DIFF
--- a/mpm/python/usrp_mpm/dboard_manager/eiscat.py
+++ b/mpm/python/usrp_mpm/dboard_manager/eiscat.py
@@ -728,4 +728,17 @@ class EISCAT(DboardManagerBase):
                 freq
             ))
 
+    def get_ref_lock(self):
+        """
+        Returns True if the LMK reference is locked.
 
+        Note: This does not return a sensor dict. The sensor API call is
+        in the motherboard class.
+        """
+        if self.lmk is None:
+            self.log.trace("LMK object not yet initialized, defaulting to " \
+                           "no ref locked!")
+            return False
+        lmk_lock_status = self.lmk.check_plls_locked()
+        self.log.trace("LMK lock status is: {}".format(lmk_lock_status))
+        return lmk_lock_status

--- a/mpm/python/usrp_mpm/dboard_manager/rhodium.py
+++ b/mpm/python/usrp_mpm/dboard_manager/rhodium.py
@@ -456,6 +456,21 @@ class Rhodium(BfrfsEEPROM, DboardManagerBase):
         " Return master clock rate (== sampling rate / 2) "
         return self.master_clock_rate
 
+    def get_ref_lock(self):
+        """
+        Returns True if the LMK reference is locked.
+
+        Note: This does not return a sensor dict. The sensor API call is
+        in the motherboard class.
+        """
+        if self.lmk is None:
+            self.log.trace("LMK object not yet initialized, defaulting to " \
+                           "no ref locked!")
+            return False
+        lmk_lock_status = self.lmk.check_plls_locked()
+        self.log.trace("LMK lock status is: {}".format(lmk_lock_status))
+        return lmk_lock_status
+
     def update_ref_clock_freq(self, freq, **kwargs):
         """
         Call this function if the frequency of the reference clock changes

--- a/mpm/python/usrp_mpm/periph_manager/n3xx.py
+++ b/mpm/python/usrp_mpm/periph_manager/n3xx.py
@@ -881,8 +881,7 @@ class n3xx(ZynqComponents, PeriphManagerBase):
             len(self.dboards)
         )
         lock_status = all([
-            not hasattr(db, 'get_ref_lock') or db.get_ref_lock()
-            for db in self.dboards
+            db.get_ref_lock() for db in self.dboards
         ])
         return {
             'name': 'ref_locked',


### PR DESCRIPTION
The "ref_locked" mboard sensor on the n320 always returned true without
querying hardware. On the n3xx family, the sensor callback in n3xx.py
returns the combination of its daughterboard LMK PLLs by querying the
get_ref_lock() function for each dboard manager instance. That function
was only written for magnesium, and for rhodium would instead just
translate to true.

This commit adds the get_ref_lock() implementations for Rhodium and
EISCAT daughterboards, which are identical to the implementation
already present for Magnesium.

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
With UHD 4.1.0.5, connected to N320 with external reference and confirmed ref_locked was true. Then plugged the external clock, and ref_locked continued to return true. With this patch, unplugging the clock causes ref_locked to return false as expected. Note once false, it remains stuck as false even if external clock is reapplied. That seems consistent across N3xx and X4xx family which read registers that have latched bits, but is different than E320 which uses a transient DLD signal. This discrepancy is a separate issue not addressed by this patch.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
