### PR TITLE
n3xx: Support clock_source=external with time_source=gpsdo

### DIFF
--- a/fpga/usrp3/top/n3xx/n3xx_clocking.v
+++ b/fpga/usrp3/top/n3xx/n3xx_clocking.v
@@ -154,7 +154,7 @@ module n3xx_clocking (
   //  ____________|              PPS              |
   // |   Clocks   | External | FPGA  | GPSDO | WR |
   // |--------------------------------------------|
-  // |External 10 |    x     |  x    |       |    |
+  // |External 10 |    x     |  x    |   x   |    |
   // |Internal 25 |          |  x    |       | x  |
   // |GPSDO    20 |          |       |   x   |    |
   // |--------------------------------------------|

--- a/mpm/python/usrp_mpm/periph_manager/n3xx.py
+++ b/mpm/python/usrp_mpm/periph_manager/n3xx.py
@@ -169,6 +169,7 @@ class n3xx(ZynqComponents, PeriphManagerBase):
         ('internal', 'sfp0'),
         ('external', 'external'),
         ('external', 'internal'),
+        ('external', 'gpsdo'),
         ('gpsdo', 'gpsdo'),
     }
     @classmethod


### PR DESCRIPTION
Update list of valid sync sources on N320 so that external refclk can be used in conjunction with internal GPSDO PPS time source.

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
We have a use case that requires using an external refclk to get very low phase noise in the receive chain, but we wanted to use the internal GPSDO PPS to provide coarse time synchronization across distributed radios. A quick review of the schematic and FPGA suggest this case should work fine, but the combination was not in the list of valid sync sources for the radio.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->
Impacts supported set of sync sources on N3xx radios.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I've done rudimentary testing on an N320 to confirm the clock locks and PPS is arriving as expected, and more thorough validation across several distributed N320s is underway.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
