### PR TITLE
n3xx: Greatly improve AD9371 based devices frequency precision

### DIFF
--- a/host/lib/usrp/dboard/magnesium/magnesium_radio_control.hpp
+++ b/host/lib/usrp/dboard/magnesium/magnesium_radio_control.hpp
@@ -211,6 +211,9 @@ private:
     //  tx_band::INVALID_BAND if the frequency is out of range.
     tx_band _map_freq_to_tx_band(const band_map_t band_map, const double freq);
 
+    // Returns fre frequency AD9371 will actually tune to according to documentation
+    double _predict_actual_lo_freq(double ret_freq);
+
     /**************************************************************************
      * Sensors
      *************************************************************************/


### PR DESCRIPTION
The classes responsible for ad9371 frequency setting on the lower levels
have integer precision, leading to frequency tuning to wrong frequencies
that won't be reported back to be compensated with DSP.

We include some code that predicts the frequency that AD9371 will
actually tune, and with that report the correct frequency, allowing
higher level classes to correctly adjust the DSP, and obtaining MUCH
higher frequency precision.

# Pull Request Details
## Description

While working with the USRP N300, we noticed that the frequencies we were requesting weren't exactly what we requested when watching the resulting signal on a spectrum analyzer(for example, `./tx_waveforms --freq 5200000009 --rate 1.25e6` would show a sinusoid at a slightly different frequency).

On further inspection, we noticed that lib mykonos, on mpm, only works with integers, and always returns the requested frequency truncated. According to the document at https://www.analog.com/media/en/technical-documentation/user-guides/ug-992.pdf, at the section RF PLL RESOLUTION LIMITATIONS, that's not actually the case, and the actual tuned frequency depends on ranges, etc. This document does not provide enough info to actually predict the tuned frequency, but using experimental data, we were able to correctly predict tuned frequencies. When returning the corred tuned frequencies, libuhd is able to compensate to the imprecision using FPGA DSP, and we get precisely the frequencies we requested when watching them under the spectrum analyzer.


## Which devices/areas does this affect?
Devices using the magnesium daughter board, we tested on the USRP N300

## Testing Done
USRP N300 with the RF0 TX/RX output going directly to a spectrum analyzer. Both devices must share a 10MHz reference.
Run the tx_waveforms example with: `./tx_waveforms --freq 5200000009 --rate 1.25e6 --ref external`.
It helps if tx_waveforms example is modified to catch the return from set_tx_freq, and print it with enough precision:
```
auto ret = usrp->set_tx_freq(tune_request, channel_nums[ch]);

printf("print good clipped rf: %25.5lf\n", ret.clipped_rf_freq);
printf("print good target rf: %25.5lf\n", ret.target_rf_freq);
printf("print good actual rf: %25.5lf\n", ret.actual_rf_freq);
printf("print good target dsp: %25.5lf\n", ret.target_dsp_freq);
printf("print good actrual dsp: %25.5lf\n", ret.target_dsp_freq);
```

Slightly vary the requested frequency, and watch how the frequency reacts at the spectrum analyzer. Before this PR, you should notice the frequency only varies at steps of ~3.7Hz, but the return from set_tx_freq reports that the hardware tuned perfectly, and the DSP does not need to do anything(which obviously isn't the case). After this PR, the return from set_tx_freq should report weird numbers for the actually tuned RF frequency, which makes the DSP actually have to be tuned, causing the resulting frequency on the output to be precise.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly. (I believe there is no modification necessary, since this works at very low level)
- [ ] I have added tests to cover my changes, and all previous tests pass. (Since these tests involve real world equipment, how would I go about this?)
- [x] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)


This is my first contribution to the project, so I would greatly appreciate any improvement suggestions, and apologize if I didn't follow any guidelines.