### PR TITLE
n320: fix issue that can cause LO to not lock when tuned the first time

### DIFF
--- a/host/lib/ic_reg_maps/gen_lmx2592_regs.py
+++ b/host/lib/ic_reg_maps/gen_lmx2592_regs.py
@@ -19,7 +19,7 @@ muxout_sel              0[2]        1       readback, lock_detect
 fcal_enable             0[3]        1
 acal_enable             0[4]        1
 fcal_lpfd_adj           0[5:6]      0       unused, 20mhz, 10mhz, 5mhz
-fcal_hpfd_adf           0[7:8]      0       unused, 100mhz, 150mhz, 200mhz
+fcal_hpfd_adj           0[7:8]      0       unused, 100mhz, 150mhz, 200mhz
 reg0_reserved0          0[9:12]     0x1
 ld_enable               0[13]       1
 reg0_reserved1          0[14:15]    0x0
@@ -78,7 +78,7 @@ reg12_reserved0         12[12:15]   0x7
 ## address 13
 ########################################################################
 reg13_reserved0         13[0:7]     0x0
-pdf_ctl                 13[8:9]     0       dual_pdf=0, single_pfd=3
+pfd_ctl                 13[8:9]     0       dual_pfd=0, single_pfd=3
 reg13_reserved1         13[10:13]   0x0
 cp_enable               13[14]      1
 reg13_reserved2         13[15]      0x0

--- a/host/lib/usrp/common/lmx2592.cpp
+++ b/host/lib/usrp/common/lmx2592.cpp
@@ -235,6 +235,8 @@ public:
             pfd_freq = input_freq / _regs.pll_r;
         }
 
+        _set_fcal_adj_values(pfd_freq);
+
         // Calculate N and frac
         const auto N_dot_F = target_vco_freq / (pfd_freq * prescaler);
         auto N             = static_cast<uint16_t>(std::floor(N_dot_F));
@@ -516,6 +518,54 @@ private: // Members
             _regs.chdiv_seg3 = lmx2592_regs_t::chdiv_seg3_t::CHDIV_SEG3_DIVIDE_BY_6;
         } else if (seg3 == 8) {
             _regs.chdiv_seg3 = lmx2592_regs_t::chdiv_seg3_t::CHDIV_SEG3_DIVIDE_BY_8;
+        }
+    }
+
+    void _set_fcal_adj_values(const double pfd_freq)
+    {
+        // Adjust FCAL speed for particularly high or low PFD frequencies
+        if(pfd_freq < 5e6)
+        {
+            _regs.fcal_lpfd_adj = lmx2592_regs_t::fcal_lpfd_adj_t::FCAL_LPFD_ADJ_5MHZ;
+            _regs.fcal_hpfd_adj = lmx2592_regs_t::fcal_hpfd_adj_t::FCAL_HPFD_ADJ_UNUSED;
+            _regs.pfd_ctl = lmx2592_regs_t::pfd_ctl_t::PFD_CTL_DUAL_PFD;
+        }
+        else if(pfd_freq < 10e6)
+        {
+            _regs.fcal_lpfd_adj = lmx2592_regs_t::fcal_lpfd_adj_t::FCAL_LPFD_ADJ_10MHZ;
+            _regs.fcal_hpfd_adj = lmx2592_regs_t::fcal_hpfd_adj_t::FCAL_HPFD_ADJ_UNUSED;
+            _regs.pfd_ctl = lmx2592_regs_t::pfd_ctl_t::PFD_CTL_DUAL_PFD;
+        }
+        else if(pfd_freq < 20e6)
+        {
+            _regs.fcal_lpfd_adj = lmx2592_regs_t::fcal_lpfd_adj_t::FCAL_LPFD_ADJ_20MHZ;
+            _regs.fcal_hpfd_adj = lmx2592_regs_t::fcal_hpfd_adj_t::FCAL_HPFD_ADJ_UNUSED;
+            _regs.pfd_ctl = lmx2592_regs_t::pfd_ctl_t::PFD_CTL_DUAL_PFD;
+        }
+        else if(pfd_freq <= 100e6)
+        {
+            _regs.fcal_lpfd_adj = lmx2592_regs_t::fcal_lpfd_adj_t::FCAL_LPFD_ADJ_UNUSED;
+            _regs.fcal_hpfd_adj = lmx2592_regs_t::fcal_hpfd_adj_t::FCAL_HPFD_ADJ_UNUSED;
+            _regs.pfd_ctl = lmx2592_regs_t::pfd_ctl_t::PFD_CTL_DUAL_PFD;
+        }
+        else if(pfd_freq <= 150e6)
+        {
+            _regs.fcal_lpfd_adj = lmx2592_regs_t::fcal_lpfd_adj_t::FCAL_LPFD_ADJ_UNUSED;
+            _regs.fcal_hpfd_adj = lmx2592_regs_t::fcal_hpfd_adj_t::FCAL_HPFD_ADJ_100MHZ;
+            _regs.pfd_ctl = lmx2592_regs_t::pfd_ctl_t::PFD_CTL_DUAL_PFD;
+        }
+        else if(pfd_freq <= 200e6)
+        {
+            _regs.fcal_lpfd_adj = lmx2592_regs_t::fcal_lpfd_adj_t::FCAL_LPFD_ADJ_UNUSED;
+            _regs.fcal_hpfd_adj = lmx2592_regs_t::fcal_hpfd_adj_t::FCAL_HPFD_ADJ_150MHZ;
+            _regs.pfd_ctl = lmx2592_regs_t::pfd_ctl_t::PFD_CTL_DUAL_PFD;
+        }
+        else
+        {
+            // Note, this case requires single-loop PFD which increases PLL noise floor
+            _regs.fcal_lpfd_adj = lmx2592_regs_t::fcal_lpfd_adj_t::FCAL_LPFD_ADJ_UNUSED;
+            _regs.fcal_hpfd_adj = lmx2592_regs_t::fcal_hpfd_adj_t::FCAL_HPFD_ADJ_200MHZ;
+            _regs.pfd_ctl = lmx2592_regs_t::pfd_ctl_t::PFD_CTL_SINGLE_PFD;
         }
     }
 


### PR DESCRIPTION
For certain frequencies, the LMX2592 will sporadically fail to lock upon
the very first tune. When this happens, subsequent tunes (even to the same
frequency) do lock. This issue seems to be resolved by programming the FCAL
adjustment register fields (FCAL_LPFD_ADJ/FCAL_HPFD_ADJ) as described in
the LMX2592 datasheet. These fields adjust the FCAL calibration speed to
better accomodate PFD frequencies below 20MHz or above 100MHz.

This patch also fixes a few name typos in the register map that were
directly in the scope of this change.

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
I was operating in receive mode at 1128 MHz, and I noticed that on some random occasions, the lo_locked sensor failed to ever assert after the first call to set_rx_freq().  Subsequent calls to set_rx_freq(), even to the same frequency, did result in a valid lo_locked result. I put together a minimal test application that repeatedly:

- Created a multi_usrp object
- Called set_rx_freq(1128e6)
- Checked the lo_locked sensor over the next two full seconds

The result is that the LO locked quickly about 75% of the time, failed to lock about 20% of the time, and locked after a long wait (>100ms) about 5% of the time. This was repeatable on three N320 units when using center frequency of 1128 MHz. It occurs with certain frequencies but not at others.

After studying the driver and datasheet, I noticed the FCAL_HPFD_ADJ register field was not being set by the driver, but for the PFD frequency being used, it should've been assigned a non-default value according to the part's datasheet.  Setting this register completely eliminates this error on my radios - 100% test iterations locked within a millisecond.

To be comprehensive, this patch will properly set FCAL_LPFD_ADJ and FCAL_HPFD_ADJ although the oscillator frequency is fixed by the hardware design, and thus FCAL_LPFD_ADJ never comes into play.

<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
Affects N320, error was reproduced on three separate units using UHD 4.1.0.5.
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
See description above.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
