### PR TITLE
host: fix EAL args for DPDK v21.11, improve frame_size assert message

### DIFF
--- a/host/lib/transport/udp_dpdk_link.cpp
+++ b/host/lib/transport/udp_dpdk_link.cpp
@@ -54,8 +54,16 @@ udp_dpdk_link::udp_dpdk_link(dpdk::port_id_t port_id,
 
     // Validate params
     const size_t max_frame_size = _port->get_mtu() - dpdk::HDR_SIZE_UDP_IPV4;
-    UHD_ASSERT_THROW(params.send_frame_size <= max_frame_size);
-    UHD_ASSERT_THROW(params.recv_frame_size <= max_frame_size);
+    if (params.send_frame_size > max_frame_size ||
+        params.recv_frame_size > max_frame_size) {
+        UHD_LOGGER_ERROR("DPDK")
+            << boost::format("recv_frame_size=%d, send_frame_size=%d, max_frame_size=%d, "
+                             "HDR_SIZE_UDP_IPV4=%d")
+                   % params.recv_frame_size % params.send_frame_size % max_frame_size
+                   % dpdk::HDR_SIZE_UDP_IPV4;
+        throw uhd::assertion_error(
+            "{ send_frame_size, recv_frame_size } > max_frame_size");
+    }
 
     // Register the adapter
     auto info      = _port->get_adapter_info();

--- a/host/lib/transport/uhd-dpdk/dpdk_common.cpp
+++ b/host/lib/transport/uhd-dpdk/dpdk_common.cpp
@@ -365,12 +365,31 @@ void dpdk_ctx::_eal_init(const device_addr_t& eal_args)
             opt = eal_add_opt(argv, end - opt, opt, "-l", val.c_str());
         } else if (key == "dpdk_coremap") {
             opt = eal_add_opt(argv, end - opt, opt, "--lcores", val.c_str());
-        } else if (key == "dpdk_master_lcore") {
+        } else if (key == "dpdk_master_lcore" || key == "dpdk_main_lcore") {
+#if RTE_VER_YEAR > 21 || (RTE_VER_YEAR == 21 && RTE_VER_MONTH >= 11)
+            opt = eal_add_opt(argv, end - opt, opt, "--main-lcore", val.c_str());
+#else
             opt = eal_add_opt(argv, end - opt, opt, "--master-lcore", val.c_str());
-        } else if (key == "dpdk_pci_blacklist") {
-            opt = eal_add_opt(argv, end - opt, opt, "-b", val.c_str());
-        } else if (key == "dpdk_pci_whitelist") {
+#endif
+        } else if (key == "dpdk_pci_blacklist" || key == "dpdk_pci_blocklist") {
+            std::stringstream ss(val);
+            while (ss.good()) {
+                std::string entry;
+                getline(ss, entry, ',');
+                opt = eal_add_opt(argv, end - opt, opt, "-b", entry.c_str());
+            }
+        } else if (key == "dpdk_pci_whitelist" || key == "dpdk_pci_allowlist") {
             opt = eal_add_opt(argv, end - opt, opt, "-w", val.c_str());
+            std::stringstream ss(val);
+            while (ss.good()) {
+                std::string entry;
+                getline(ss, entry, ',');
+#if RTE_VER_YEAR > 21 || (RTE_VER_YEAR == 21 && RTE_VER_MONTH >= 11)
+                opt = eal_add_opt(argv, end - opt, opt, "-a", entry.c_str());
+#else
+                opt = eal_add_opt(argv, end - opt, opt, "-w", entry.c_str());
+#endif
+            }
         } else if (key == "dpdk_log_level") {
             opt = eal_add_opt(argv, end - opt, opt, "--log-level", val.c_str());
         } else if (key == "dpdk_huge_dir") {


### PR DESCRIPTION
# Pull Request Details
21.11 removed EAL args master/blacklist/whitelist,
I added forward/backwards compatibility for these changes.
Added ability to specify multiple PCIs in the allow/block list (any vers).
Improved frame_size/MTU debugging messages  (any vers).

## Related Issue
Accompanies #547 #548 

## Which devices/areas does this affect?
DPDK transport

## Testing Done
Verified on DPDK v21.11 that EAL args dpdk_master_lcore, 
dpdk_pci_blacklist, and dpdk_pci_whitelist now function and
do not produce a fatal error.
Verified that the new comma separated list functionality for 
dpdk_pci_blacklist and dpdk_pci_whitelist  work.

When your frame_sizes are too large, DPDK no properly explains the 
MTU and the transport overhead in an error message to aid debug.

Tested on Ubuntu 22.04 and 20.04, x86_64.
Tested with Mellanox ConnectX-4 and ConnectX-5 under mlx5 kernel 
mode driver.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
