### PR TITLE
host: x300: C++ FW Reset API

### DIFF
--- a/host/include/uhd/utils/CMakeLists.txt
+++ b/host/include/uhd/utils/CMakeLists.txt
@@ -37,6 +37,7 @@ UHD_INSTALL(FILES
     tasks.hpp
     thread_priority.hpp
     thread.hpp
+    x300_fw_reset.hpp
     DESTINATION ${INCLUDE_DIR}/uhd/utils
     COMPONENT headers
 )

--- a/host/include/uhd/utils/x300_fw_reset.hpp
+++ b/host/include/uhd/utils/x300_fw_reset.hpp
@@ -1,0 +1,26 @@
+//
+// Copyright 2022 Ettus Research, a National Instruments Brand
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+#pragma once
+
+#include <uhd/config.hpp>
+#include <uhd/error.h>
+#include <uhd/types/device_addr.hpp>
+#include <chrono>
+#include <cstdint>
+
+namespace uhd { namespace usrp {
+
+const uint32_t X300_FW_RESET_REG  = 0x100058;
+const uint32_t X300_FW_RESET_DATA = 1;
+
+const std::chrono::milliseconds X300_FW_RESET_SLEEP_TIME =
+    std::chrono::milliseconds(5000UL);
+
+UHD_API uhd_error x300_fw_reset(const uhd::device_addr_t& dev_addr,
+    std::chrono::milliseconds sleep_time = X300_FW_RESET_SLEEP_TIME);
+
+}} // namespace uhd::usrp

--- a/host/lib/transport/udp_dpdk_link.cpp
+++ b/host/lib/transport/udp_dpdk_link.cpp
@@ -54,8 +54,16 @@ udp_dpdk_link::udp_dpdk_link(dpdk::port_id_t port_id,
 
     // Validate params
     const size_t max_frame_size = _port->get_mtu() - dpdk::HDR_SIZE_UDP_IPV4;
-    UHD_ASSERT_THROW(params.send_frame_size <= max_frame_size);
-    UHD_ASSERT_THROW(params.recv_frame_size <= max_frame_size);
+    if (params.send_frame_size > max_frame_size ||
+        params.recv_frame_size > max_frame_size) {
+        UHD_LOGGER_ERROR("DPDK")
+            << boost::format("recv_frame_size=%d, send_frame_size=%d, max_frame_size=%d, "
+                             "HDR_SIZE_UDP_IPV4=%d")
+                   % params.recv_frame_size % params.send_frame_size % max_frame_size
+                   % dpdk::HDR_SIZE_UDP_IPV4;
+        throw uhd::assertion_error(
+            "{ send_frame_size, recv_frame_size } > max_frame_size");
+    }
 
     // Register the adapter
     auto info      = _port->get_adapter_info();

--- a/host/lib/transport/uhd-dpdk/dpdk_common.cpp
+++ b/host/lib/transport/uhd-dpdk/dpdk_common.cpp
@@ -365,12 +365,31 @@ void dpdk_ctx::_eal_init(const device_addr_t& eal_args)
             opt = eal_add_opt(argv, end - opt, opt, "-l", val.c_str());
         } else if (key == "dpdk_coremap") {
             opt = eal_add_opt(argv, end - opt, opt, "--lcores", val.c_str());
-        } else if (key == "dpdk_master_lcore") {
+        } else if (key == "dpdk_master_lcore" || key == "dpdk_main_lcore") {
+#if RTE_VER_YEAR > 21 || (RTE_VER_YEAR == 21 && RTE_VER_MONTH >= 11)
+            opt = eal_add_opt(argv, end - opt, opt, "--main-lcore", val.c_str());
+#else
             opt = eal_add_opt(argv, end - opt, opt, "--master-lcore", val.c_str());
-        } else if (key == "dpdk_pci_blacklist") {
-            opt = eal_add_opt(argv, end - opt, opt, "-b", val.c_str());
-        } else if (key == "dpdk_pci_whitelist") {
+#endif
+        } else if (key == "dpdk_pci_blacklist" || key == "dpdk_pci_blocklist") {
+            std::stringstream ss(val);
+            while (ss.good()) {
+                std::string entry;
+                getline(ss, entry, ',');
+                opt = eal_add_opt(argv, end - opt, opt, "-b", entry.c_str());
+            }
+        } else if (key == "dpdk_pci_whitelist" || key == "dpdk_pci_allowlist") {
             opt = eal_add_opt(argv, end - opt, opt, "-w", val.c_str());
+            std::stringstream ss(val);
+            while (ss.good()) {
+                std::string entry;
+                getline(ss, entry, ',');
+#if RTE_VER_YEAR > 21 || (RTE_VER_YEAR == 21 && RTE_VER_MONTH >= 11)
+                opt = eal_add_opt(argv, end - opt, opt, "-a", entry.c_str());
+#else
+                opt = eal_add_opt(argv, end - opt, opt, "-w", entry.c_str());
+#endif
+            }
         } else if (key == "dpdk_log_level") {
             opt = eal_add_opt(argv, end - opt, opt, "--log-level", val.c_str());
         } else if (key == "dpdk_huge_dir") {

--- a/host/lib/usrp/x300/x300_eth_mgr.cpp
+++ b/host/lib/usrp/x300/x300_eth_mgr.cpp
@@ -32,9 +32,6 @@
 #include <boost/asio.hpp>
 #include <string>
 
-uhd::wb_iface::sptr x300_make_ctrl_iface_enet(
-    uhd::transport::udp_simple::sptr udp, bool enable_errors = true);
-
 using namespace uhd;
 using namespace uhd::usrp;
 using namespace uhd::rfnoc;

--- a/host/lib/usrp/x300/x300_eth_mgr.hpp
+++ b/host/lib/usrp/x300/x300_eth_mgr.hpp
@@ -20,6 +20,9 @@
 #include <map>
 #include <vector>
 
+uhd::wb_iface::sptr x300_make_ctrl_iface_enet(
+    uhd::transport::udp_simple::sptr udp, bool enable_errors = true);
+
 namespace uhd { namespace usrp { namespace x300 {
 
 /*! Helper class to manage the eth connections

--- a/host/lib/utils/CMakeLists.txt
+++ b/host/lib/utils/CMakeLists.txt
@@ -235,6 +235,7 @@ LIBUHD_APPEND_SOURCES(
     ${CMAKE_CURRENT_SOURCE_DIR}/system_time.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/thread.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/x300_fw_reset.cpp
 )
 
 if(ENABLE_C_API)

--- a/host/lib/utils/x300_fw_reset.cpp
+++ b/host/lib/utils/x300_fw_reset.cpp
@@ -1,0 +1,39 @@
+//
+// Copyright 2022 Ettus Research, a National Instruments Brand
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+#include "../usrp/x300/x300_eth_mgr.hpp"
+#include <uhd/transport/udp_simple.hpp>
+#include <uhd/types/wb_iface.hpp>
+#include <uhd/utils/x300_fw_reset.hpp>
+#include <thread>
+
+namespace uhd { namespace usrp {
+
+uhd_error x300_fw_reset(
+    const uhd::device_addr_t& dev_addr, std::chrono::milliseconds sleep_time)
+{
+    // It is not possible to reset device if IP address is not provided
+    if (!dev_addr.has_key("addr")) {
+        return UHD_ERROR_INVALID_DEVICE;
+    }
+
+    // Reset Scope
+    // Create UDP connection
+    uhd::transport::udp_simple::sptr udp_simple =
+        uhd::transport::udp_simple::make_connected(
+            dev_addr["addr"], BOOST_STRINGIZE(X300_FW_COMMS_UDP_PORT));
+
+    // Create X300 control
+    uhd::wb_iface::sptr x300_ctrl = x300_make_ctrl_iface_enet(udp_simple, true);
+
+    // Reset FPGA firmware
+    x300_ctrl->poke32(X300_FW_RESET_REG, X300_FW_RESET_DATA);
+
+    std::this_thread::sleep_for(sleep_time);
+    return UHD_ERROR_NONE;
+}
+
+}} // namespace uhd::usrp


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->
Added utility API for resetting the x3xx FW
This is a C++ extension of the Python utility "x300_reset.py"

**NOTE:
I don't believe the placement of this API makes sense for the 
UHD structure, but I would like to post this anyway to start the
ball rolling for a proper solution. If someone could comment
the best place to implement this functionality - please let me know =]**

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
USRP x3xx's occasionally become hard-locked after terminating a
session improperly (main issue).
This is a band-aid fix that allows a software reset instead of a hard
power cycle.
This also allows certain resets to be performed for other misc. use cases.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Related #253 

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->
USRP x3xx

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested on X310 with 2x TwinRX daughterboards, properly resets and allows
the device to be claimed again.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
