### PR TITLE
host: Remove redundant template parameter list

### DIFF
--- a/host/include/uhd/property_tree.ipp
+++ b/host/include/uhd/property_tree.ipp
@@ -21,7 +21,7 @@ template <typename T>
 class property_impl : public property<T>
 {
 public:
-    property_impl<T>(property_tree::coerce_mode_t mode) : _coerce_mode(mode)
+    property_impl(property_tree::coerce_mode_t mode) : _coerce_mode(mode)
     {
         if (_coerce_mode == property_tree::AUTO_COERCE) {
             _coercer = DEFAULT_COERCER;


### PR DESCRIPTION
## Description
C++20 no longer allows redundant template parameter lists. The template parameter list must be removed from the `property_impl` constructor to allow C++20 projects to include UHD.

## Related Issue
Fixes #589.

## Which devices/areas does this affect?
`property_tree`

## Testing Done
None, apart from verifying that compilation succeeds in C++20 mode.

## Checklist
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] ~~I have updated the documentation accordingly.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
- [x] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
