### PR TITLE
e3xx: Add support for power calibration API

### DIFF
--- a/host/docs/usrp_e3xx.dox
+++ b/host/docs/usrp_e3xx.dox
@@ -598,6 +598,15 @@ The following daughterboard sensors are always available:
 - `ad9361_temperature`: Temperature sensor of the RFIC die
 - `rssi`: RSSI value as returned from the AD9361 (RX only)
 
+\subsection e3xx_power_api Power API
+
+The E3xx series support the UHD power calibration API (see: \ref page_power).
+The TX path and the two RX paths per channel each have their own calibration
+data, resulting in 6 sets of calibration data per E3xx device.
+
+Devices have to be manually calibrated using a calibrated power meter or
+signal generator.
+
 \section e3xx_rasm Remote Management
 
 \subsection e3xx_rasm_mender Mender: Remote update capability


### PR DESCRIPTION
This adds support for the power calibration API to the E3xx radio
family (e.g. the set_[tx|rx]_power_reference() API calls). It also includes
support within the uhd_power_cal.py utility script and updates the E3xx
documentation.

## Description
This PR primarily updates the e3xx radio_control impl to include support for the pwr_cal_mgr interface. This allows the radio family to support the set_[tx|rx]_power_reference() API calls. The python utilities were updated to include a "calibrator" subclass for this radio family, so that the existing uhd_power_cal.py utility can be used to generate calibration tables for these radios. Finally, the e3xx documentation was updated to mention support for this API, similar to the blurbs that exist in the B200/X3xx documentation.

Because the pwr_cal_mgr accesses the radio_control_impl's gain setter, the set-lock used by the e3xx_radio_control_impl was changed from a mutex to a recursive_mutex. This allows the gain update to occur while processing the frequency change, without releasing the lock in between. I noted that recursive mutexes are already in use across the codebase, including in other radio_control impls.

## Implementation Note!
One observation to consider: calibration data is generated and uniquely identified per antenna, per direction, per channel. This means that for RX on a given channel, the antennas RX2 and TX/RX are expected to have separate calibration tables. None of the existing devices that support power calibration API seem to handle this correctly - they all create an instance of pwr_cal_mgr identified by the default antenna in each direction, and that table gets used for any port. For example, on most (all?) devices, the receive cal table for "RX2" will be used regardless of whether "RX2" or "TX/RX" is selected, despite the fact that generation is implied to be antenna-specific.

In this patch, I deviated from that behavior and tried to respect that independent tables are maintained for each of the two RX antenna ports per channel on the E320. Instead of just instantiating one pwr_cal_mgr per direction per channel, like other devices do, I instead create one _per antenna_ per direction per channel. Then I reference into the correct manager if the antenna selection is changed. However I am currently not maintaining the power-tracking across antenna change, although perhaps that would be desirable.

If adhering to separate cal table per antenna is not desirable, then the patch should be changed to be more in line with other impls. However, in that case, I'd also suggest updating the calibration generation and keying to reflect that. Or, perhaps an approach where antenna-specific data is preferred if available, otherwise fallback to only use the default antenna data.. ?

<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Which devices/areas does this affect?
The change only impacts E3xx radios.
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
I confirmed that I can generate TX calibration tables for an E320 using the existing uhd_power_cal.py, those tables are referenced appropriately by the E320 device, and it tracks TX power levels after I call set_tx_power_reference(). Further, I confirmed that gain settings are updated correctly upon re-tune, that each TX channel is tracked separately, and that manually setting tx_gain will exit power-tracking mode. Functionality was confirmed by querying the tx_gain setting after re-tune, and also viewing transmit power levels on a spectrum analyzer.

I did _not_ test RX power tracking (which I don't use), nor did I test any radio in the E3xx family beyond the E320.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
