### PR TITLE
doc: Fix generation of man pages

### DIFF
--- a/host/docs/CMakeLists.txt
+++ b/host/docs/CMakeLists.txt
@@ -124,7 +124,7 @@ set(man_page_sources
 )
 
 if (ENABLE_PYTHON_API)
-    set(man_page_sources
+    list(APPEND man_page_sources
         usrpctl.1
     )
 endif(ENABLE_PYTHON_API)


### PR DESCRIPTION
Commit 99ad89609b6c71faff625adbb0a284bc2d405601 introduced a regression: most of the man pages are not generated when the Python API is enabled.
This pull request fixes this bug.