### PR TITLE
Use error_code instead of return_code in stderr

### DIFF
--- a/host/examples/rx_samples_c.c
+++ b/host/examples/rx_samples_c.c
@@ -212,7 +212,7 @@ int main(int argc, char* argv[])
             uhd_rx_metadata_error_code(md, &error_code)
         )
         if(error_code != UHD_RX_METADATA_ERROR_CODE_NONE){
-            fprintf(stderr, "Error code 0x%x was returned during streaming. Aborting.\n", return_code);
+            fprintf(stderr, "Error code 0x%x was returned during streaming. Aborting.\n", error_code);
             goto close_file;
         }
 


### PR DESCRIPTION
# Pull Request Details

## Description
This PR fixes the returning stderr error code when streaming with usrp in the sample code (rx_samples_c.c)

## Related Issue

## Which devices/areas does this affect?

## Testing Done

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes, and all previous tests pass.
- [x] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
