### PR TITLE
E320: Allow internal GPSDO to be powered-down via UHD session args 

### DIFF
--- a/host/docs/configuration.dox
+++ b/host/docs/configuration.dox
@@ -272,7 +272,7 @@ The following key/value pairs are understood:
 
  Key                 | Description                                                                  | Supported Devices | Example Value
 ---------------------|------------------------------------------------------------------------------|-------------------|---------------------
- enable_gps          | Enable/disable power to the GPSDO.                                           | N3xx, E320        | enable_gps=0
+ enable_gps          | Enable/disable power to the GPSDO (can be overridden by UHD on E320).        | N3xx, E320        | enable_gps=0
  enable_fp_gpio      | Enable/disable power to the front-panel GPIOs.                               | N3xx, E320        | enable_fp_gpio=0
  skip_boot_init      | Don't init the device during MPM boot, but on the first UHD run.             | N3xx              | skip_boot_init=1
  clock_source        | Default clock source for this device (can be overridden by UHD).             | N3xx, E320, E31x  | clock_source=external

--- a/host/docs/usrp_e3xx.dox
+++ b/host/docs/usrp_e3xx.dox
@@ -546,6 +546,7 @@ For a list of which arguments can be passed into make(), see Section
  skip_init           | Skip the initialization process for the device.                               | skip_init=1
  discovery_port      | Override default value for MPM discovery port.                                | discovery_port=49700
  rpc_port            | Override default value for MPM RPC port.                                      | rpc_port=49701
+ enable_gps          | Enable/disable power to the integrated GPSDO (E320 only).                     | enable_gps=0
 
 \subsection e3xx_usage_sensors The sensor API
 

--- a/host/docs/usrp_e3xx.dox
+++ b/host/docs/usrp_e3xx.dox
@@ -1312,6 +1312,10 @@ Unlike the E31x, but like most other USRPs, the USRP E320 has separate inputs fo
 clock and time reference. There is no separate internal 10 MHz oscillator, when
 selecting an 'internal' reference, the GPSDO is used to create reference signals.
 
+To reduce phase noise, it may be necessary to power down the GPSDO when using
+an external reference.  To do this, just add `enable_gps=False` to args when
+connecting to the radio (see also \ref page_configfiles).
+
 The values 'internal' and 'gpsdo' are thus interchangeable and mean the same
 thing.
 


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
This patch allows a UHD application to power-down the GPSDO on an E320 radio by specifying the "enable_gps" arg at MPM connection time. Previously, the arg was only supported when the MPM daemon is launched at radio power-on. When used, the power-state of the GPSDO is only changed for the current MPM session - it will be restored to default upon session deinit.

It's useful for a UHD application to control the GPSDO power state, because the GPSDO seems to induce phase noise when using an external clock. Now an application using clock_source=external can also specify enable_gps=0 at the same time, when phase noise performance is important.

As a separate commit, this PR also updates the e3xx doc to mention this phase noise consideration. The same language is already present in the N320 docs, and is alluded to as a "known issue" in the B200 docs. It was not previously mentioned for the E3xx series.

## Related Issue
For more information and plots, see internal support emails exchanged with Wan Liu titled "PLL phase perturbations using any external clock with E320".

## Which devices/areas does this affect?
E320 only

## Testing Done
I've confirmed the flag now works at connection-time when connecting to an E320 radio. I've also confirmed using this flag to disable the GPSDO fixes the additive phase noise issue. Finally, I've confirmed the GPSDO reverts back to its default power state when the MPM session ends.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
