### PR TITLE
fix UHDAtomics.cmake to read custom Boost install prefix

### DIFF
--- a/host/cmake/Modules/UHDAtomics.cmake
+++ b/host/cmake/Modules/UHDAtomics.cmake
@@ -36,6 +36,7 @@ endfunction(CHECK_WORKING_CXX_ATOMICS64)
 # Note: If we reach this, we have already checked for the existence of Boost,
 # and Boost.Lockfree is a header-only library so no linker options required.
 function(CHECK_WORKING_CXX_BOOST_ATOMICS varname)
+    set(CMAKE_REQUIRED_INCLUDES ${Boost_INCLUDE_DIRS})
     CHECK_CXX_SOURCE_COMPILES("
         #include <boost/lockfree/queue.hpp>
         boost::lockfree::queue<int> queue(1);


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This fixes a CMake build issue with custom prefix-installed Boost libraries.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Resolves #632

## Which devices/areas does this affect?
NA, this is a build issue.

## Testing Done
CMake proceeds.

## Checklist

- [ x] I have read the CONTRIBUTING document.
- [ x] My code follows the code style of this project. See CODING.md.
- [ x] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes, and all previous tests pass.
- [ x] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
