### PR TITLE
USRP2: fix "RuntimeError: fifo ctrl timed out looking for acks"

### DIFF
--- a/host/lib/usrp/usrp2/usrp2_fifo_ctrl.cpp
+++ b/host/lib/usrp/usrp2/usrp2_fifo_ctrl.cpp
@@ -46,9 +46,6 @@ public:
     ~usrp2_fifo_ctrl_impl(void) override
     {
         _timeout = ACK_TIMEOUT; // reset timeout to something small
-        UHD_SAFE_CALL(
-            this->peek32(0); // dummy peek with the purpose of ack'ing all packets
-        )
     }
 
     /*******************************************************************


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Deleted "this->peek32(0)" from usrp2_fifo_ctrl_impl destructor - fixes "RuntimeError: fifo ctrl timed out looking for acks", and enables USRP2 to operate successfully with GnuRadio.  This bug has been reported on the mailing list multiple times (e.g. [this 2018 thread](https://www.mail-archive.com/usrp-users@lists.ettus.com/msg06954.html), [this current thread](https://lists.ettus.com/empathy/thread/OUO3AWZGCWTTTITX7Y2R4CV6UY6ZBIV2) ), but not previously addressed as the USRP2 is regarded as obsolete.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->
USRP2, operation with GnuRadio.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Patch tested against UHD v4.1.0.5 under Ubuntu Linux 22.04, with GnuRadio 3.10.1.1 (example GnuRadio Companion script with USRP2 acting as a receiver).  Also fixes the same error seen in console output from the "uhd_usrp_probe" utility.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [ ] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
