### PR TITLE
host: fix build with DPDK v22.11 LTS

### DIFF
--- a/host/lib/include/uhdlib/transport/dpdk/common.hpp
+++ b/host/lib/include/uhdlib/transport/dpdk/common.hpp
@@ -10,6 +10,7 @@
 #include <uhd/transport/frame_buff.hpp>
 #include <uhd/types/device_addr.hpp>
 #include <uhdlib/transport/adapter_info.hpp>
+#include <rte_arp.h>
 #include <rte_ethdev.h>
 #include <rte_ether.h>
 #include <rte_flow.h>

--- a/host/lib/transport/uhd-dpdk/dpdk_common.cpp
+++ b/host/lib/transport/uhd-dpdk/dpdk_common.cpp
@@ -93,8 +93,13 @@ dpdk_port::dpdk_port(port_id_t port,
     /* Set hardware offloads */
     struct rte_eth_dev_info dev_info;
     rte_eth_dev_info_get(_port, &dev_info);
+#ifdef RTE_ETH_RX_OFFLOAD_IPV4_CKSUM
+    uint64_t rx_offloads = RTE_ETH_RX_OFFLOAD_IPV4_CKSUM;
+    uint64_t tx_offloads = RTE_ETH_TX_OFFLOAD_IPV4_CKSUM;
+#else
     uint64_t rx_offloads = DEV_RX_OFFLOAD_IPV4_CKSUM;
     uint64_t tx_offloads = DEV_TX_OFFLOAD_IPV4_CKSUM;
+#endif
     if ((dev_info.rx_offload_capa & rx_offloads) != rx_offloads) {
         UHD_LOGGER_ERROR("DPDK") << boost::format("%d: Only supports RX offloads 0x%0llx")
                                         % _port % dev_info.rx_offload_capa;
@@ -192,7 +197,11 @@ dpdk_port::dpdk_port(port_id_t port,
         }
 
         struct rte_eth_txconf txconf = dev_info.default_txconf;
+#ifdef RTE_ETH_TX_OFFLOAD_IPV4_CKSUM
+        txconf.offloads              = RTE_ETH_TX_OFFLOAD_IPV4_CKSUM;
+#else
         txconf.offloads              = DEV_TX_OFFLOAD_IPV4_CKSUM;
+#endif
         retval = rte_eth_tx_queue_setup(_port, i, tx_desc, cpu_socket, &txconf);
         if (retval < 0) {
             UHD_LOGGER_ERROR("DPDK")


### PR DESCRIPTION
Some defines were changed, and a header is no longer recursively included so needs to be specified given its definitions are used directly.

# Pull Request Details
Fix build with DPDK v22.11, while maintaining compatibility with older versions

## Testing Done
Build-tested only

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
