### PR TITLE
Fix build with GCC 13 (add missing <cstdint> include)

### DIFF
--- a/host/include/uhd/cal/database.hpp
+++ b/host/include/uhd/cal/database.hpp
@@ -8,6 +8,7 @@
 
 #include <uhd/config.hpp>
 #include <stddef.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <functional>

--- a/host/include/uhd/rfnoc/defaults.hpp
+++ b/host/include/uhd/rfnoc/defaults.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace uhd { namespace rfnoc {

--- a/host/include/uhd/types/eeprom.hpp
+++ b/host/include/uhd/types/eeprom.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/host/include/uhd/usrp/zbx_tune_map_item.hpp
+++ b/host/include/uhd/usrp/zbx_tune_map_item.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 #include <uhd/config.hpp>
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <vector>

--- a/host/lib/usrp/dboard/magnesium/magnesium_constants.hpp
+++ b/host/lib/usrp/dboard/magnesium/magnesium_constants.hpp
@@ -9,6 +9,7 @@
 
 #include <uhd/types/ranges.hpp>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/host/lib/usrp/dboard/rhodium/rhodium_constants.hpp
+++ b/host/lib/usrp/dboard/rhodium/rhodium_constants.hpp
@@ -9,6 +9,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/host/lib/utils/serial_number.cpp
+++ b/host/lib/utils/serial_number.cpp
@@ -5,6 +5,7 @@
 //
 
 #include <uhdlib/utils/serial_number.hpp>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 


### PR DESCRIPTION
# Pull Request Details

## Description

GCC 13 (as usual for new compiler releases) shuffles around some internal includes and so <cstdint> is no longer transitively included.

Explicitly include <cstdint> for uint8_t.

```
/var/tmp/portage/net-wireless/uhd-4.3.0.0/work/uhd-4.3.0.0/host/include/uhd/rfnoc/defaults.hpp:43:14: error: 'uint32_t' does not name a type
   43 | static const uint32_t DEFAULT_NOC_ID  = 0xFFFFFFFF;
      |              ^~~~~~~~
/var/tmp/portage/net-wireless/uhd-4.3.0.0/work/uhd-4.3.0.0/host/include/uhd/rfnoc/defaults.hpp:1:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
  +++ |+#include <cstdint>
    1 | //
```

## Related Issue
N/A

## Which devices/areas does this affect?
Any builds with GCC.

## Testing Done
Tested with various compiler versions.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [X] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
