### PR TITLE
Add in OpenBSD support to uhd::path_expandvars

### DIFF
--- a/host/lib/utils/pathslib.cpp
+++ b/host/lib/utils/pathslib.cpp
@@ -9,6 +9,8 @@
 
 #ifdef BOOST_MSVC
 #    include <windows.h>
+#elif defined(__OpenBSD__)
+#    include <glob.h>
 #else
 #    include <wordexp.h>
 #endif
@@ -27,6 +29,17 @@ std::string uhd::path_expandvars(const std::string& path)
         return path;
     }
     return std::string(result, result + result_len);
+#elif defined(__OpenBSD__)
+    glob_t p;
+    std::string return_value;
+    memset(&p, 0, sizeof(p));
+    if (glob(path.c_str(), GLOB_TILDE, NULL, &p) == 0 && p.gl_pathc > 0) {
+        return_value = std::string(p.gl_pathv[0]);
+    } else {
+        return_value = path;
+    }
+    globfree(&p);
+    return return_value;
 #else
     wordexp_t p;
     std::string return_value;


### PR DESCRIPTION
OpenBSD has explicitly declined[1] to support 'wordexp' on their platform, which just leaves glob(3) for expanding strings according to shell-like rules. The API is similar, but -- notably -- does not support environment variable expansion (for instance, the string "/home/${USER_NAME}/" will be left unchanged, whereas wordexp(3) would expand it).

However, OpenBSD supports the well understood but non-POSIX extension to glob, 'GLOB_TILDE', which will allow for user directory expansion, such as '~user/.ssh/authorized_keys' or '~/bin/*.sh'.

This is a fairly large difference between OpenBSD and other supported platforms, but one that will at least enable libuhd to be built, but users may need to be careful with filepaths, since they'll behave slightly differently on OpenBSD than Windows, Linux or OSX.

```
sugartoad# uhd_find_devices
[INFO] [UHD] OpenBSD 1; Clang version 13.0.0 ; Boost_108000; UHD_4.4.0.0-68-g02558b69
[INFO] [B200] Loading firmware image: /usr/local/share/uhd/images/usrp_b200_fw.hex...
--------------------------------------------------
-- UHD Device 0
--------------------------------------------------
Device Address:
    serial: XXXXXXX
    name: MyB210
    product: B210
    type: b200
```

[1]: https://www.mail-archive.com/tech@openbsd.org/msg02325.html

## Which devices/areas does this affect?

Building `libuhd` on OpenBSD.

## Testing Done

Building `libuhd` requires OpenBSD 7.3 from snapshots (current release is 7.2), because the `waitid(2)` syscall was only just added to OpenBSD. Which is to say, the `master` branch will still fail to build until the 7.3 release.

USB I/O isn't working still with my Ettus B210 and B200mini, due to constraints of `libusb` on OpenBSD, I believe. Some follow-on MRs may come out of that, but this would (at least) work with networked USRP devices, as well as talking via USB without streaming, yet. I also suspect it's possible to fix that without changes to `libuhd`. That being said, this doesn't impact just `libuhd` -- `rtl-sdr` has a note in the OpenBSD port about async usb transfer not working right. I don't think OpenBSD users would find this note particularly shocking.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)

My 2c: I do not believe `libuhd` should claim any meaningful OpenBSD support yet. This platform has been (for the history of this project) totally DOA, so I suspect these changes won't impact any users yet.
