### PR TITLE
host: Add cstdint include to fix gcc-13 compile.

### DIFF
--- a/host/lib/include/uhdlib/utils/compat_check.hpp
+++ b/host/lib/include/uhdlib/utils/compat_check.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 namespace uhd {


### PR DESCRIPTION
# Pull Request Details

## Description
In GCC 13 release some C++ Standard Library headers no longer include other headers that were being used internally. This means some headers that were implicit, now need to be included in C++ programs explicitly. (See https://gcc.gnu.org/gcc-13/porting_to.html)

This includes `<cstdint>`, and therefore the build from source of uhd host with gcc-13 fails without explicitly including this header. (See output below.)

This simple commit resolves the issue on GCC version `gcc (GCC) 13.1.1 20230429`

```
In file included from /home/phil/Projects/uhd/host/tests/compat_test.cpp:7:
/home/phil/Projects/uhd/host/lib/include/uhdlib/utils/compat_check.hpp:67:40: error: ‘uint8_t’ was not declared in this scope
   67 | class compat_num16 : public compat_num<uint8_t, uint8_t>
      |                                        ^~~~~~~
/home/phil/Projects/uhd/host/lib/include/uhdlib/utils/compat_check.hpp:11:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   10 | #include <string>
  +++ |+#include <cstdint>
   11 | 
/home/phil/Projects/uhd/host/lib/include/uhdlib/utils/compat_check.hpp:67:49: error: ‘uint8_t’ was not declared in this scope
   67 | class compat_num16 : public compat_num<uint8_t, uint8_t>
...
```

## Which devices/areas does this affect?
Compilation of UHD host applications only.

## Testing Done
Issue encountered on archlinux, with GCC version `gcc (GCC) 13.1.1 20230429`
Fix has been tested successfully on:
- Archlinux, `gcc (GCC) 13.1.1 20230429`
- Ubuntu 20.04, `gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0` (no regression observed)

## Checklist

- [x ] I have read the CONTRIBUTING document.
- [x ] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)

I believe this change to be sufficiently trivial so as not to require a signed CLA.