### PR TITLE
fpga/usrp3: Fix DC truncation bias for B2xx by adding rounding to DDC chain

### DIFF
--- a/fpga/usrp3/lib/dsp/hb_dec.v
+++ b/fpga/usrp3/lib/dsp/hb_dec.v
@@ -26,7 +26,7 @@ module hb_dec
      output reg [WIDTH-1:0] data_out);
 
    localparam INTWIDTH = 17;
-   localparam ACCWIDTH = WIDTH + 3;
+   localparam ACCWIDTH = 30;
 
    // Round off inputs to 17 bits because of 18 bit multipliers
    wire [INTWIDTH-1:0] 	     data_rnd;
@@ -173,21 +173,26 @@ module hb_dec
    reg [35:0] 	     sum_of_prod;
    always @(posedge clk) sum_of_prod <= prod1 + prod2;   // Can't overflow
 
-   wire [ACCWIDTH-1:0] 	acc_out;
-   acc #(.IWIDTH(ACCWIDTH-2),.OWIDTH(ACCWIDTH))
-     acc (.clk(clk),.clear(clear),.acc(do_acc),.in(sum_of_prod[35:38-ACCWIDTH]),.out(acc_out));
+   wire [35:0] 	acc_out;
+   acc #(.IWIDTH(36),.OWIDTH(36))
+     acc (.clk(clk),.clear(clear),.acc(do_acc),.in(sum_of_prod),.out(acc_out));
 
-   wire [ACCWIDTH-1:0] 	data_even_signext;
+   wire [WIDTH:0] acc_out_rnd;
+   round #(.bits_in(36),.bits_out(WIDTH+1)) round_acc
+     (.in(acc_out), .out(acc_out_rnd));
 
-   localparam SHIFT_FACTOR = 6;
+   wire [WIDTH:0]     data_even_signext;
 
-   sign_extend #(.bits_in(INTWIDTH),.bits_out(ACCWIDTH-SHIFT_FACTOR)) signext_data_even
-     (.in(data_even),.out(data_even_signext[ACCWIDTH-1:SHIFT_FACTOR]));
-   assign 		data_even_signext[SHIFT_FACTOR-1:0] = 0;
+   localparam SHIFT_FACTOR = 17 - (36 - (WIDTH+1));
 
-   always @(posedge clk) final_sum <= acc_out + data_even_signext;
+   sign_extend #(.bits_in(INTWIDTH),.bits_out(WIDTH+1-SHIFT_FACTOR)) signext_data_even
+     (.in(data_even),.out(data_even_signext[WIDTH:SHIFT_FACTOR]));
+   assign       data_even_signext[SHIFT_FACTOR-1:0] = 0;
 
-   clip #(.bits_in(WIDTH+1), .bits_out(WIDTH)) clip (.in(final_sum), .out(final_sum_clip));
+   always @(posedge clk) final_sum <= acc_out_rnd + data_even_signext;
+
+   clip #(.bits_in(WIDTH+1),.bits_out(WIDTH)) clip_finalsum
+     (.in(final_sum), .out(final_sum_clip));
 
    // Output MUX to allow for bypass
    wire 		selected_stb = bypass ? stb_in : stb_out_pre[8];

--- a/fpga/usrp3/lib/dsp/small_hb_dec.v
+++ b/fpga/usrp3/lib/dsp/small_hb_dec.v
@@ -110,13 +110,18 @@ module small_hb_dec
    localparam ACCWIDTH = 30;
    reg [ACCWIDTH-1:0] 	 accum;
 
+   wire [ACCWIDTH-1:0] prod_acc_rnd;
+   round #(.bits_in(36),.bits_out(ACCWIDTH),
+           .round_to_zero(1),.round_to_nearest(0),.trunc(0)) round_prod
+     (.in(prod), .out(prod_acc_rnd));
+
    always @(posedge clk)
      if(rst)
        accum <= 0;
      else if(go_d2)
-       accum <= {middle_d1[17],middle_d1[17],middle_d1,{(16+ACCWIDTH-36){1'b0}}} + {prod[35:36-ACCWIDTH]};
+       accum <= {middle_d1[17],middle_d1[17],middle_d1,{(16+ACCWIDTH-36){1'b0}}} + prod_acc_rnd;
      else if(go_d3)
-       accum <= accum + {prod[35:36-ACCWIDTH]};
+       accum <= accum + prod_acc_rnd;
 
    wire [WIDTH:0] 	 accum_rnd;
    wire [WIDTH-1:0] 	 accum_rnd_clip;


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Currently, the non-RFNOC usrp3 (i.e. B2xx) DDC code truncates to 18 bits from 24 bits after applying the halfband filters and before applying a scaling and final rounding. This truncation introduces a DC bias that is noticeable with small signal levels (or lots of integration), especially with high decimation rates. Changing the truncation to a rounding removes the DC bias.

This is essentially a forward port of a similar prior fix to the usrp2 DDC chain: https://github.com/EttusResearch/fpga/pull/4. (Note: In order to not repeat the mistake of finding a similar issue in another part of the codebase ~8 years later =P, I checked the RFNOC usrp3's DDC to see what it does. Thankfully, it doesn't have this problem since it uses a wider multiplier and thus avoids the truncation.)

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->
USRP3-based non-RFNOC devices, i.e. B2xx and B2xxmini

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I tested this with a B200mini using GNU Radio. Without the radio connected to anything, I tuned with an LO offset of 1 MHz, gain of 0, and high decimation factor (master clock of 40e6, sample rate of 200e3). Using the stock fpga, a DC bias is present:
![b200mini_fpga_stock](https://github.com/EttusResearch/uhd/assets/4391207/66fdedb4-22c2-4f8c-806d-f5d15ca59216)

Using this modification, the DC bias is gone:
![b200mini_fpga_with_rounding](https://github.com/EttusResearch/uhd/assets/4391207/ba02644b-2fc0-4e7e-920c-710aec0e8637)

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
