### PR TITLE
dpdk: fix build with new DPDK 23.11

### DIFF
--- a/host/lib/transport/uhd-dpdk/dpdk_io_service.cpp
+++ b/host/lib/transport/uhd-dpdk/dpdk_io_service.cpp
@@ -267,7 +267,11 @@ int dpdk_io_service::_io_worker(void* arg)
 
     char name[16];
     snprintf(name, sizeof(name), "dpdk-io_%hu", (uint16_t)lcore_id);
+#if RTE_VER_YEAR >= 23
+    rte_thread_set_name(rte_thread_self(), name);
+#else
     rte_thread_setname(pthread_self(), name);
+#endif
     UHD_LOG_TRACE("DPDK::IO_SERVICE",
         "I/O service thread '" << name << "' started on lcore " << lcore_id);
 


### PR DESCRIPTION
## Description
Since 23.03 rte_thread_setname was deprecated and in 23.11 it is gone. Adapt to the new name `rte_thread_set_name`.
See the [release notes](https://doc.dpdk.org/guides/rel_notes/release_23_11.html) for more.

## Testing Done
Test build against DPDK 23.11 as it is prepared for Debian and Ubuntu
=> https://launchpad.net/~paelzer/+archive/ubuntu/dpdk-23.11-test-builds/+build/27035932
Build fails without the fix
https://launchpad.net/~paelzer/+archive/ubuntu/dpdk-23.11-test-builds/+build/27035895

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have added tests to cover my changes, and all previous tests pass.
- [n/a] I have checked all compat numbers if they need updating (FPGA compat, MPM compat, noc_shell, specific RFNoC block, ...)