### PR TITLE
x3xx DAC interpolator value documentation

### DIFF
--- a/host/lib/usrp/x300/x300_dac_ctrl.cpp
+++ b/host/lib/usrp/x300/x300_dac_ctrl.cpp
@@ -156,6 +156,8 @@ public:
         write_ad9146_reg(0x03, (1 << 6)); // 2s comp, i first, byte mode
 
         // Configure interpolation filters
+        // Both Halfband Filters are set to Mode 0 for an interpolation
+        // factor of 4, without frequency shift and modulation
         write_ad9146_reg(0x1C, 0x00); // Configure HB1
         write_ad9146_reg(0x1D, 0x00); // Configure HB2
         write_ad9146_reg(0x1B, 0xE4); // Bypass: Modulator, InvSinc, IQ Bal


### PR DESCRIPTION
added 2 lines of comments to clarify that the DAC runs with an interpolation factor of 4

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

Due to a customer escalation we found out why we mention 800 MS/s on X3xx and 2974 Hardware Resources page. The DAC runs with an interpolation factor of 4 (200 MS/s * 4 = 800MS/s). 

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Just 2 lines of code

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

none

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

x3xx and 2974 documentation

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

none, since it is only documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes, and all previous tests pass.
- [x] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
