### PR TITLE
host: Add OctoClock Python API

### DIFF
--- a/host/lib/usrp_clock/multi_usrp_clock_python.cpp
+++ b/host/lib/usrp_clock/multi_usrp_clock_python.cpp
@@ -18,16 +18,11 @@ void export_multi_usrp_clock(py::module& m)
 {
     using multi_usrp_clock = uhd::usrp_clock::multi_usrp_clock;
 
-    // Const?
-
     // clang-format off
     py::class_<multi_usrp_clock, multi_usrp_clock::sptr>(m, "multi_usrp_clock")
 
         // Factory
         .def(py::init(&multi_usrp_clock::make))
-
-        // clang-format off
-        //.def("get_tree"                , [](multi_usrp_clock& self){ return self.get_tree().get(); }, py::return_value_policy::reference_internal)
 
         // General OCTOCLOCK methods
         .def("get_pp_string"           , &multi_usrp_clock::get_pp_string)

--- a/host/lib/usrp_clock/multi_usrp_clock_python.cpp
+++ b/host/lib/usrp_clock/multi_usrp_clock_python.cpp
@@ -1,0 +1,41 @@
+//
+// Copyright 2017-2018 Ettus Research, a National Instruments Company
+// Copyright 2019-2020 Ettus Research, a National Instruments Brand
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+#include <pybind11/complex.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+#include "multi_usrp_clock_python.hpp"
+#include <uhd/usrp_clock/multi_usrp_clock.hpp>
+
+void export_multi_usrp_clock(py::module& m)
+{
+    using multi_usrp_clock = uhd::usrp_clock::multi_usrp_clock;
+
+    // Const?
+
+    // clang-format off
+    py::class_<multi_usrp_clock, multi_usrp_clock::sptr>(m, "multi_usrp_clock")
+
+        // Factory
+        .def(py::init(&multi_usrp_clock::make))
+
+        // clang-format off
+        //.def("get_tree"                , [](multi_usrp_clock& self){ return self.get_tree().get(); }, py::return_value_policy::reference_internal)
+
+        // General OCTOCLOCK methods
+        .def("get_pp_string"           , &multi_usrp_clock::get_pp_string)
+        .def("get_num_boards"          , &multi_usrp_clock::get_num_boards)
+        .def("get_time"                , &multi_usrp_clock::get_time, py::arg("board") = 0)
+        .def("get_sensor"              , &multi_usrp_clock::get_sensor, py::arg("name"), py::arg("board") = 0)
+        .def("get_sensor_names"        , &multi_usrp_clock::get_sensor_names, py::arg("board") = 0)
+        // clang-format off
+        ;
+    // clang-format on
+}

--- a/host/lib/usrp_clock/multi_usrp_clock_python.hpp
+++ b/host/lib/usrp_clock/multi_usrp_clock_python.hpp
@@ -1,0 +1,10 @@
+//
+// Copyright 2017-2018 Ettus Research, a National Instruments Company
+// Copyright 2019 Ettus Research, a National Instruments Brand
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+#pragma once
+
+void export_multi_usrp_clock(py::module& m);

--- a/host/python/CMakeLists.txt
+++ b/host/python/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(pyuhd SHARED
     ${UHD_SOURCE_DIR}/lib/property_tree_python.cpp
     ${UHD_SOURCE_DIR}/lib/device_python.cpp
     ${UHD_SOURCE_DIR}/lib/usrp/multi_usrp_python.cpp
+    ${UHD_SOURCE_DIR}/lib/usrp_clock/multi_usrp_clock_python.cpp
 )
 # python expects extension modules with a particular suffix
 if(WIN32)

--- a/host/python/pyuhd.cpp
+++ b/host/python/pyuhd.cpp
@@ -44,6 +44,7 @@ namespace py = pybind11;
 #include "usrp/fe_connection_python.hpp"
 #include "usrp/multi_usrp_python.hpp"
 #include "usrp/subdev_spec_python.hpp"
+#include "usrp_clock/multi_usrp_clock_python.hpp"
 #include "utils/paths_python.hpp"
 #include "utils/utils_python.hpp"
 
@@ -87,6 +88,10 @@ PYBIND11_MODULE(libpyuhd, m)
     export_dboard_iface(usrp_module);
     export_fe_connection(usrp_module);
     export_stream(usrp_module);
+
+    // Register usrp clock submodule
+    auto usrp_clock_module = m.def_submodule("usrp_clock", "USRP Clock Objects");
+    export_multi_usrp_clock(usrp_clock_module);
 
     // Register filters submodule
     auto filters_module = m.def_submodule("filters", "Filter Submodule");

--- a/host/python/uhd/__init__.py
+++ b/host/python/uhd/__init__.py
@@ -9,6 +9,7 @@ UHD Python API module
 
 from . import types
 from . import usrp
+from . import usrp_clock
 from . import usrpctl
 from . import filters
 from . import rfnoc

--- a/host/python/uhd/usrp_clock/__init__.py
+++ b/host/python/uhd/usrp_clock/__init__.py
@@ -1,0 +1,10 @@
+#
+# Copyright 2020 Ettus Research, a National Instruments Brand
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+""" @package usrp_clock
+Python UHD module containing the MultiUSRPClock
+"""
+
+from .multi_usrp_clock import MultiUSRPClock

--- a/host/python/uhd/usrp_clock/multi_usrp_clock.py
+++ b/host/python/uhd/usrp_clock/multi_usrp_clock.py
@@ -1,0 +1,20 @@
+#
+# Copyright 2017-2018 Ettus Research, a National Instruments Company
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+""" @package usrp_clock
+Python UHD module containing the MultiUSRPClock
+"""
+
+from .. import libpyuhd as lib
+
+
+class MultiUSRPClock(lib.usrp_clock.multi_usrp_clock):
+    """
+    MultiUSRPClock object for controlling devices
+    """
+    def __init__(self, args=""):
+        """MultiUSRPClock constructor"""
+        super(MultiUSRPClock, self).__init__(args)
+

--- a/host/tests/devtest/multi_usrp_clock_test.py
+++ b/host/tests/devtest/multi_usrp_clock_test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+#
+# Copyright 2018 Ettus Research, a National Instruments Company
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+""" Test all python API functions for the connected device. """
+
+import sys
+import argparse
+import uhd
+
+
+# pylint: disable=broad-except
+
+def time_test(clock, num_mboards):
+    """
+    Test if each Octoclock returs a time value.
+
+    clock -- Device object to run tests on.
+    num_mboards -- Integer value of number of Octoclocks.
+    """
+    for mboard in range(0, num_mboards):
+        time = getattr(clock, 'get_time')(mboard)
+        if time is None:
+            raise Exception(f'get_time() function on Octoclock {mboard} returns None')
+        else:
+            print(f'[Octo {mboard}] Current time: {time}')
+    return True
+
+
+def test_sensor_api(clock, num_mboards):
+    """
+    Test the sensor API. It consists of two API calls ("get_sensor_names" and
+    "get_sensor"). It will read out all the sensors and print their values
+    for each octoclock.
+
+    clock -- Device object to run tests on.
+    num_mboards -- Integer value of number of Octoclocks.
+    """
+
+    for mboard in range(num_mboards):
+        sensor_names = getattr(clock, 'get_sensor_names')(mboard)
+        print(f'[Octo {mboard}] Got {len(sensor_names)} sensors.')
+
+        for i, sensor_name in enumerate(sensor_names):
+            sensor_value = getattr(clock, 'get_sensor')(sensor_name, mboard)
+            print(f'[{i}/{len(sensor_names)}] ({sensor_name}) {str(sensor_value)}')
+
+
+class MethodExecutor(object):
+    """
+    Object for executing tests. Handles returned errors and mantains
+    tested & failed lists.
+    """
+    def __init__(self):
+        self.tested = []
+        self.failed = []
+
+    def execute_methods(self, method_names, method_callback):
+        """
+        Execute API methods in 'method_names' by calling 'method_callback'.
+
+        The callback must throw an exception if something went wrong. If no
+        exception is thrown, the assumption is that all went fine.
+
+        method_names -- List of methods that will be called.
+        method_callback -- String containing the method to call.
+        """
+        self.tested.extend(method_names)
+        method_names_str = ", ".join([method + "()" for method in method_names])
+        print(f"Executing methods: {method_names_str}")
+        try:
+            method_callback()
+        except Exception as ex:
+            print(f"Error while executing methods: \n`{method_names_str}`:\n{ex}",
+                  file=sys.stderr)
+            self.failed.extend(method_names)
+            return False
+        return True
+
+
+def run_api_test(clock):
+    """
+    Name functions to be tested.
+    clock -- device object to run tests on
+    """
+    num_mboards = clock.get_num_boards()
+
+    method_executor = MethodExecutor()
+
+    method_executor.tested.extend(('make',
+                                   'get_num_mboards', #  Got called above
+    ))
+
+    actual_tests = [
+        (['get_pp_string'], clock.get_pp_string),
+        (['get_sensor_names', 'get_sensor'],
+         lambda: test_sensor_api(clock, num_mboards)),
+        (['get_time'],
+         lambda: time_test(clock, num_mboards)),
+    ]
+
+    success = True
+    # ...then we can run them all through the executor like this:
+    for method_names, test_callback in actual_tests:
+        if not method_executor.execute_methods(method_names, test_callback):
+            success = False
+
+    if method_executor.failed:
+        print("The following API calls caused failures:")
+        print("* " + "\n* ".join(method_executor.failed))
+
+    return success
+
+
+def parse_args():
+    """
+    Parse args.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--args', default='addr=192.168.10.3',
+    )
+    return parser.parse_args()
+
+
+def main():
+    """
+    Returns True on Success
+    """
+    args = parse_args()
+    clock = uhd.usrp_clock.MultiUSRPClock(args.args)
+    ret_val = run_api_test(clock)
+
+    if ret_val != 1:
+        raise Exception("Python API Tester Received Errors")
+    return ret_val
+
+if __name__ == "__main__":
+    sys.exit(not main())


### PR DESCRIPTION
# Pull Request Details

## Description
An extension of the Python API to enable access to all OctoClock methods. The code is based on the existing multi_usrp implementation. 

## Related Issue
The question of a Python implementation for the OctoClock was mentioned [here](https://www.mail-archive.com/usrp-users@lists.ettus.com/msg13831.html) in the mailing list.

## Which devices/areas does this affect?
The changes affect the OctoClock and OctoClock-G.

## Testing Done
The provided test `multi_usrp_clock_test.py` was successfully executed with an OctoClock-G CDA-2990. Please note that the test was not run with more than one OctoClock as I only have one currently available.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
