### PR TITLE
host: Fix RFNoC graph action queue lockup on action exceptions

### DIFF
--- a/host/tests/actions_test.cpp
+++ b/host/tests/actions_test.cpp
@@ -221,3 +221,29 @@ BOOST_AUTO_TEST_CASE(test_action_forwarding_map_exception_invalid_destination)
     auto cmd = action_info::make("action");
     BOOST_REQUIRE_THROW(generator.post_output_edge_action(cmd, 0), uhd::rfnoc_error);
 }
+
+BOOST_AUTO_TEST_CASE(test_action_exception_handling)
+{
+    node_accessor_t node_accessor{};
+    uhd::rfnoc::detail::graph_t graph{};
+
+    class mock_throwing_node_t : public mock_radio_node_t
+    {
+    public:
+        mock_throwing_node_t() : mock_radio_node_t(0)
+        {
+            register_action_handler(
+                "throwing_action", [](const res_source_info&, action_info::sptr) {
+                    throw uhd::runtime_error("Arbitrary UHD exception");
+                });
+        }
+    };
+
+    mock_throwing_node_t mock_radio{};
+    graph.connect(&mock_radio, &mock_radio, {0, 0, graph_edge_t::DYNAMIC, false});
+    graph.commit();
+    // Check that it throws the first time
+    BOOST_REQUIRE_THROW(node_accessor.post_action(&mock_radio, {res_source_info::USER, 0}, action_info::make("throwing_action")), uhd::runtime_error);
+    // It should also throw the second time: we should actually be running this action even though the previous one threw an exception
+    BOOST_REQUIRE_THROW(node_accessor.post_action(&mock_radio, {res_source_info::USER, 0}, action_info::make("throwing_action")), uhd::runtime_error);
+}


### PR DESCRIPTION

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Processing of the action queue gets locked up when any action being executed in the `send_action` call throws an exception. Exceptions are not caught in the loop handling the action queue, resulting in the `handling_ongoing` queue locking flag to never be released. Any subsequent call to `enqueue_action` will return on the early exit with the assumption that we're already handling the actions, yet the previous handler exited with an exception.

This fix uses a RAII wrapper rather than a manually claimed and released atomic flag to ensure that the handling_ongoing will be released even under exceptional conditions.

## Related Issue
Relates to issue #611

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->
UHD hosts using RFNoC graph

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

X310 with dual 10GbE links to server, running both RF inputs at 200MHz sample rate using 2x RX streamers.
Stress the server with CPU load (can use `stress-ng`), inducing UDP packet drops. (Also relates to  #611, which stressed the link using iperf, probably also causing UDP packet drops).
At some point (difficult to reproduce, but does happen every so often), one of the RX streamers will experience an overrun, which calls the [_overrun_handler](https://github.com/EttusResearch/uhd/blob/080b1baac3af63842fa598729ed5442b4a79285a/host/lib/rfnoc/rfnoc_rx_streamer.cpp#L158) -> [ACTION_KEY_RX_RESTART_REQ](https://github.com/EttusResearch/uhd/blob/080b1baac3af63842fa598729ed5442b4a79285a/host/lib/rfnoc/radio_control_impl.cpp#L92) which calls `get_time_now()`, doing a [peek64](https://github.com/EttusResearch/uhd/blob/080b1baac3af63842fa598729ed5442b4a79285a/host/lib/rfnoc/radio_control_impl.cpp#L348) to the device. This `peek64` then throws an [exception](https://github.com/EttusResearch/uhd/blob/080b1baac3af63842fa598729ed5442b4a79285a/host/lib/rfnoc/ctrlport_endpoint.cpp#L499) due to an ACK timeout. 

This exception is caught all the way up in thread that called `recv` on the RX streamer, but the stream is irrecoverable since the graph action queue is locked up.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
