### PR TITLE
readme: fix srsRAN URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ third-party applications. Some common toolkits / frameworks are:
 * [OpenBTS GSM](http://openbts.org)
 * [Osmocom GSM](https://osmocom.org)
 * [Amarisoft LTE](https://www.amarisoft.com/products-lte-ue-ots-sdr-pcie)
-* [Software Radio Systems srsRAN](https://www.softwareradiosystems.com/products)
+* [Software Radio Systems srsRAN](https://www.srsran.com/)
 * [Eurecom OpenAirInterface](https://gitlab.eurecom.fr/oai/openairinterface5g)
 
 ## Directories


### PR DESCRIPTION
# Pull Request Details

This PR fixes the URL pointing to the srsRAN page in the readme.

## Description

If people click on the srsRAN link they end up with a 404.

## Checklist

Most of the below are not applicable.

- [x] I have read the CONTRIBUTING document.
- [ ] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
