### PR TITLE
host/include/uhd/types/bye_vector.hpp: include cstdint

### DIFF
--- a/host/include/uhd/types/byte_vector.hpp
+++ b/host/include/uhd/types/byte_vector.hpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace uhd {
 


### PR DESCRIPTION
Include cstdint to fix the following build failure:

```
In file included from /home/buildroot/instance-0/output-1/build/uhd-4.3.0.0/host/lib/types/byte_vector.cpp:9: /home/buildroot/instance-0/output-1/build/uhd-4.3.0.0/host/include/uhd/types/byte_vector.hpp:19:21: error: 'uint8_t' was not declared in this scope; did you mean 'boost::uint8_t'?
   19 | typedef std::vector<uint8_t> byte_vector_t;
      |                     ^~~~~~~
      |                     boost::uint8_t
```

Fixes:
 - http://autobuild.buildroot.org/results/2cba1535b42e36a62b611af01088622912b277e7