### PR TITLE
e320: Ensure consistent sequencing when powering on/off GPSDO

### DIFF
--- a/mpm/python/usrp_mpm/periph_manager/e320.py
+++ b/mpm/python/usrp_mpm/periph_manager/e320.py
@@ -10,6 +10,7 @@ E320 implementation module
 import bisect
 import copy
 import re
+import time
 from functools import partial
 from six import iteritems
 from usrp_mpm.compat_num import CompatNumber
@@ -261,7 +262,11 @@ class e320(ZynqComponents, PeriphManagerBase):
         # Init peripherals
         self._gps_enabled = None  # Assume indeterminant, will latch _def_gps_enabled
         self._def_gps_enabled = str2bool(args.get('enable_gps', E320_DEFAULT_ENABLE_GPS))
-        self.enable_gps(self._def_gps_enabled)
+        # Ensure clean power-on for GPS receiver
+        self.enable_gps(False)
+        if self._def_gps_enabled:
+            time.sleep(0.100) # held off for 100ms
+            self.enable_gps(True)
         self.enable_fp_gpio(
             enable=args.get('enable_fp_gpio', E320_DEFAULT_ENABLE_FPGPIO)
         )


### PR DESCRIPTION
# Pull Request Details
When powering up the GPSDO, ensure the GPS_3V3 rail is up before taking the GPSDO out of reset. When powering down the GPSDO, ensure I/O signals are driven low to ensure GPSDO isn't backfed power via its I/O input pins.

It's worth noting that this PR doesn't address a specific issue, but rather is an improvement in behavior I noted when I was troubleshooting an unrelated GPSDO issue.

## Which devices/areas does this affect?
Impacts MPM control of GPS power state on USRP E320 radios.

## Testing Done
Confirmed that updated logic functions as expected, "e320_bist gpsdo" functions as expected on the radio, and GPSDO can be powered on and powered off as expected.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
