### PR TITLE
e320: Ensure GPSDO is cleanly reset upon radio power-on

### DIFF
--- a/mpm/python/usrp_mpm/periph_manager/e320.py
+++ b/mpm/python/usrp_mpm/periph_manager/e320.py
@@ -10,6 +10,7 @@ E320 implementation module
 import bisect
 import copy
 import re
+import time
 from functools import partial
 from six import iteritems
 from usrp_mpm.compat_num import CompatNumber
@@ -261,7 +262,11 @@ class e320(ZynqComponents, PeriphManagerBase):
         # Init peripherals
         self._gps_enabled = None  # Assume indeterminant, will latch _def_gps_enabled
         self._def_gps_enabled = str2bool(args.get('enable_gps', E320_DEFAULT_ENABLE_GPS))
-        self.enable_gps(self._def_gps_enabled)
+        # Ensure clean power-on for GPS receiver
+        self.enable_gps(False)
+        if self._def_gps_enabled:
+            time.sleep(0.100) # held off for 100ms
+            self.enable_gps(True)
         self.enable_fp_gpio(
             enable=args.get('enable_fp_gpio', E320_DEFAULT_ENABLE_FPGPIO)
         )


### PR DESCRIPTION
This patch performs an explicit reset on the GPSDO when the E320 MPM service is initialized upon boot. This ensures the GPSDO HW is always in a known power-on reset state when MPM starts up.

## Description
It's worth noting that this PR doesn't address a specific known problem, but rather was a way to ensure the GPSDO HW is always brought into a known reinitialized state upon startup, using MPM functions that manage HW state. Previously initial pin levels were simply set when the FPGA is loaded, which may differ in timing/sequencing from MPM pin control logic.

I was on the fence about submitting as a PR since any benefit is unclear at best, but figured I'd defer to your judgement. I needed to ensure GPS was being initialized consistently across a cluster of E320 radios including upon soft reboot.

## Which devices/areas does this affect?
MPM running on USRP E320.

## Testing Done
Confirmed GPSDO operates as expected upon power-up. Confirmed GPSDO undergoes a HW reset if the USRP MPM service is restarted on the radio.
## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
