### PR TITLE
CMake improvements and compiler warning fixes

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -14,10 +14,11 @@ cmake_minimum_required(VERSION 3.8)
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW) # Suppress Version warnings
 endif(POLICY CMP0048)
+
 project(UHD CXX C)
 enable_testing()
 
-#make sure our local CMake Modules path comes first
+# Make sure our local CMake Modules path comes first
 list(INSERT CMAKE_MODULE_PATH 0 ${UHD_SOURCE_DIR}/cmake/Modules)
 
 ########################################################################
@@ -206,6 +207,8 @@ if(APPLE)
     if(NOT CMAKE_BUILD_WITH_INSTALL_RPATH)
         set(CMAKE_BUILD_WITH_INSTALL_RPATH ON CACHE
             BOOL "Do Build Using Library Install RPath" FORCE)
+        set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON CACHE
+            BOOL "Set install name to install name dir during build" FORCE)
     endif(NOT CMAKE_BUILD_WITH_INSTALL_RPATH)
 endif(APPLE)
 
@@ -302,7 +305,7 @@ set(UHD_BOOST_REQUIRED_COMPONENTS
 
 include(UHDBoost)
 
-include_directories(${Boost_INCLUDE_DIRS})
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
 ########################################################################

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -21,10 +21,12 @@ enable_testing()
 # Make sure our local CMake Modules path comes first
 list(INSERT CMAKE_MODULE_PATH 0 ${UHD_SOURCE_DIR}/cmake/Modules)
 
+
 ########################################################################
 # UHD Dependency Minimum Versions are stored in a separate file
 ########################################################################
 include(UHDMinDepVersions)
+
 
 ########################################################################
 # Check Compiler Version
@@ -52,21 +54,22 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
         RESULT_VARIABLE res ERROR_VARIABLE err
         ERROR_STRIP_TRAILING_WHITESPACE)
     if(${res} STREQUAL "0")
-        # output is in error stream
+        # Version output is in error stream
         string(REGEX MATCH "^Apple.*" IS_APPLE ${err})
+
+        # Retrieve the compiler's version
         if("${IS_APPLE}" STREQUAL "")
             set(MIN_VERSION ${UHD_CLANG_MIN_VERSION})
             set(APPLE_STR "")
-            # retrieve the compiler's version from it
             string(REGEX MATCH "clang version [0-9.]+" CLANG_OTHER_VERSION ${err})
             string(REGEX MATCH "[0-9.]+" CLANG_VERSION ${CLANG_OTHER_VERSION})
         else()
             set(MIN_VERSION ${UHD_APPLECLANG_MIN_VERSION})
             set(APPLE_STR "Apple ")
-            # retrieve the compiler's version from it
             string(REGEX MATCH "(clang-[0-9.]+)" CLANG_APPLE_VERSION ${err})
             string(REGEX MATCH "[0-9.]+" CLANG_VERSION ${CLANG_APPLE_VERSION})
         endif()
+
         if(${CLANG_VERSION} VERSION_LESS "${MIN_VERSION}")
             message(WARNING
               "\nThe compiler selected to build UHD "
@@ -99,10 +102,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "C
     set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
 endif()
 
+
 ########################################################################
 # Packaging Variables
 ########################################################################
-
 option(UNDERSCORE_UHD_VERSION "Replace dashes in uhd version with underscores" OFF)
 set(LIBUHD_PKG ${LIBUHD_PKG} CACHE BOOL "Build Debian libuhd003 package")
 set(LIBUHDDEV_PKG ${LIBUHDDEV_PKG} CACHE BOOL "Build Debian libuhd-dev package")
@@ -110,10 +113,11 @@ set(UHDHOST_PKG ${UHDPOST_PKG} CACHE BOOL "Build Debian uhd-host package")
 include(UHDComponent) #enable components
 include(UHDPackage)   #setup cpack
 
+
 ########################################################################
 # Install Dirs
 ########################################################################
-#when the library suffix should be 64 (applies to redhat linux family)
+# Whether the library suffix should be 64 (applies to redhat linux family)
 if(NOT DEFINED LIB_SUFFIX AND REDHAT AND CMAKE_SYSTEM_PROCESSOR MATCHES "64$")
     set(LIB_SUFFIX 64)
 endif()
@@ -133,6 +137,7 @@ if(NOT DEFINED PKG_DOC_DIR)
     set(PKG_DOC_DIR share/doc/uhd)
 endif()
 set(PKG_MAN_DIR share/man/man1)
+
 
 ########################################################################
 # UHD config files
@@ -158,6 +163,7 @@ else()
     message(WARNING "Not setting UHD_SYS_CONF_FILE!")
 endif()
 
+
 ########################################################################
 # UHD Image Directories
 ########################################################################
@@ -176,11 +182,13 @@ if(DEFINED UHD_IMAGES_DIR_WINREG_KEY)
     add_definitions(-DUHD_IMAGES_DIR_WINREG_KEY=${UHD_IMAGES_DIR_WINREG_KEY})
 endif(DEFINED UHD_IMAGES_DIR_WINREG_KEY)
 
+
 ########################################################################
 # Local Include Dir
 ########################################################################
 include_directories(${UHD_BINARY_DIR}/include)
 include_directories(${UHD_SOURCE_DIR}/include)
+
 
 ########################################################################
 # Static Lib Configuration
@@ -190,8 +198,9 @@ if(ENABLE_STATIC_LIBS)
     message(STATUS "Building Static Libraries: ${ENABLE_STATIC_LIBS}")
 endif(ENABLE_STATIC_LIBS)
 
+
 ########################################################################
-# On Apple only, set install name and use rpath correctly, if not already set
+# On Apple only, set install name and rpath correctly if not already set
 ########################################################################
 if(APPLE)
     if(NOT CMAKE_INSTALL_NAME_DIR)
@@ -212,6 +221,7 @@ if(APPLE)
     endif(NOT CMAKE_BUILD_WITH_INSTALL_RPATH)
 endif(APPLE)
 
+
 ########################################################################
 # Optional Compiler Flags
 ########################################################################
@@ -223,14 +233,14 @@ macro(UHD_ADD_OPTIONAL_CXX_COMPILER_FLAG flag have)
     endif(${have})
 endmacro(UHD_ADD_OPTIONAL_CXX_COMPILER_FLAG)
 
-#select the release build type by default to get optimization flags
+# Select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)
    set(CMAKE_BUILD_TYPE "Release")
    message(STATUS "Build type not specified: defaulting to release.")
 endif(NOT CMAKE_BUILD_TYPE)
 set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING "")
 
-#force UHD_RELEASE_MODE to be a string for cmake-gui
+# Force UHD_RELEASE_MODE to be a string for cmake-gui
 set(UHD_RELEASE_MODE "${UHD_RELEASE_MODE}" CACHE STRING "UHD Release Mode")
 
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" OR
@@ -247,13 +257,14 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" OR
     #add_definitions(-pedantic)
     #add_definitions(-ansi)
     if(NOT WIN32)
-        #only export symbols that are declared to be part of the uhd api (non dll platforms)
+        # Only export symbols that are declared to be part of the uhd api (non dll platforms)
         UHD_ADD_OPTIONAL_CXX_COMPILER_FLAG(-fvisibility=hidden HAVE_VISIBILITY_HIDDEN)
         UHD_ADD_OPTIONAL_CXX_COMPILER_FLAG(-fvisibility-inlines-hidden HAVE_VISIBILITY_INLINES_HIDDEN)
     endif(NOT WIN32)
     if(${CMAKE_BUILD_TYPE} STREQUAL "Coverage")
         include(CodeCoverage)
-        setup_target_for_coverage(coverage "ctest || return 0" coverage) # never fail ctest, always generate coverage report
+        # Never fail ctest, always generate coverage report
+        setup_target_for_coverage(coverage "ctest || return 0" coverage)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -pthread -g -O0 -fprofile-arcs -ftest-coverage" CACHE STRING "Flags used by the C++ compiler during Coverage builds." FORCE)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -pthread -g -O0 -fprofile-arcs -ftest-coverage" CACHE STRING "Flags used by the C compiler during Coverage builds." FORCE)
     endif()
@@ -261,7 +272,8 @@ endif()
 
 if(MSVC)
     include_directories(${UHD_SOURCE_DIR}/cmake/msvc)
-    add_definitions( #stop all kinds of compatibility warnings
+    # Stop all kinds of compatibility warnings
+    add_definitions(
         -DWIN32_LEAN_AND_MEAN
         -DVC_EXTRALEAN
         -D_SCL_SECURE_NO_WARNINGS
@@ -272,18 +284,19 @@ if(MSVC)
         -D_CRT_NONSTDC_NO_DEPRECATE
         -D_WINSOCK_DEPRECATED_NO_WARNINGS
     )
-    # multi-threaded build and increases the number of addressable sections in an .obj file.
+    # Enable multi-threaded build and increase the number of addressable sections in an .obj file.
     add_compile_options(/MP /bigobj)
 endif(MSVC)
 
 if(CYGWIN)
-    add_definitions(-D__USE_W32_SOCKETS) #boost asio says we need this
+    add_definitions(-D__USE_W32_SOCKETS) # boost asio says we need this
 endif(CYGWIN)
 
 if(WIN32)
-    add_definitions(-D_WIN32_WINNT=0x0501) #minimum version required is windows xp
-    add_definitions(-DNOMINMAX) #disables stupidity and enables std::min and std::max
+    add_definitions(-D_WIN32_WINNT=0x0501) # minimum version required is windows xp
+    add_definitions(-DNOMINMAX) # disables stupidity and enables std::min and std::max
 endif(WIN32)
+
 
 ########################################################################
 # Setup Boost
@@ -308,11 +321,13 @@ include(UHDBoost)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
+
 ########################################################################
 # Additional settings for build environment
 ########################################################################
 include(UHDGlobalDefs)
 include(UHDLog)
+
 
 ########################################################################
 # Check Python Modules
@@ -358,6 +373,7 @@ UHD_PYTHON_CHECK_MODULE_VERSION(
     ${UHD_RUAMEL_YAML_MIN_VERSION}
     HAVE_PYTHON_MODULE_YAML
 )
+
 
 ########################################################################
 # Option to use QEMU for running unittests
@@ -412,6 +428,7 @@ if(ENABLE_QEMU_UNITTESTS)
     message(STATUS "  QEMU sysroot: ${QEMU_SYSROOT}")
 endif(ENABLE_QEMU_UNITTESTS)
 
+
 ########################################################################
 # Create Uninstall Target
 ########################################################################
@@ -424,6 +441,7 @@ add_custom_target(uninstall
     ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
 )
 
+
 ########################################################################
 # Install Package Docs
 ########################################################################
@@ -433,6 +451,7 @@ UHD_INSTALL(FILES
     DESTINATION ${PKG_DOC_DIR}
     COMPONENT readme
 )
+
 
 ########################################################################
 # Register top level components
@@ -452,6 +471,7 @@ LIBUHD_REGISTER_COMPONENT(
     ENABLE_PYMOD_UTILS ON
     "HAVE_PYTHON_MODULE_NUMPY;HAVE_PYTHON_MODULE_MAKO;HAVE_PYTHON_MODULE_YAML"
     OFF OFF)
+
 
 ########################################################################
 # Add the subdirectories
@@ -480,6 +500,7 @@ if(ENABLE_PYTHON_API OR ENABLE_PYMOD_UTILS)
     add_subdirectory(python)
 endif()
 
+
 ########################################################################
 # Create Pkg Config File
 ########################################################################
@@ -491,12 +512,12 @@ foreach(lib ${Boost_LIBRARY_DIRS})
     list(APPEND UHD_PC_LIBS "-L${lib}")
 endforeach(lib)
 
-#use space-separation format for the pc file
+# Use space-separation format for the pc file
 string(REPLACE ";" " " UHD_PC_REQUIRES "${UHD_PC_REQUIRES}")
 string(REPLACE ";" " " UHD_PC_CFLAGS "${UHD_PC_CFLAGS}")
 string(REPLACE ";" " " UHD_PC_LIBS "${UHD_PC_LIBS}")
 
-#unset these vars to avoid hard-coded paths to cross environment
+# Unset these vars to avoid hard-coded paths to cross environment
 if(CMAKE_CROSSCOMPILING)
     set(UHD_PC_CFLAGS)
     set(UHD_PC_LIBS)
@@ -558,6 +579,7 @@ UHD_INSTALL(
     COMPONENT "devel"
 )
 
+
 ########################################################################
 # Handle pre-built UHD Images for packaging
 ########################################################################
@@ -570,6 +592,7 @@ if(DEFINED UHD_IMAGES_SRC_DIR AND EXISTS "${UHD_IMAGES_SRC_DIR}")
     endforeach(_img)
     UHD_INSTALL(FILES ${_image_files} DESTINATION ${PKG_DATA_DIR}/images COMPONENT images)
 endif(DEFINED UHD_IMAGES_SRC_DIR AND EXISTS "${UHD_IMAGES_SRC_DIR}")
+
 
 ########################################################################
 # Print Summary

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -318,6 +318,7 @@ set(UHD_BOOST_REQUIRED_COMPONENTS
 
 include(UHDBoost)
 
+# Include boost headers as system headers to avoid compiler warnings from them.
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 

--- a/host/cmake/Modules/FindDPDK.cmake
+++ b/host/cmake/Modules/FindDPDK.cmake
@@ -19,5 +19,12 @@ include(FindPackageHandleStandardArgs)
 find_package(PkgConfig)
 PKG_CHECK_MODULES(DPDK libdpdk>=18.11)
 
-find_package_handle_standard_args(DPDK DEFAULT_MSG DPDK_INCLUDE_DIRS DPDK_CFLAGS DPDK_LDFLAGS DPDK_LIBRARIES)
+find_package_handle_standard_args(
+    DPDK
+    DEFAULT_MSG
+    DPDK_INCLUDE_DIRS
+    DPDK_CFLAGS DPDK_LDFLAGS
+    DPDK_LIBRARIES
+    HANDLE_VERSION_RANGE
+)
 mark_as_advanced(DPDK_INCLUDE_DIRS DPDK_CFLAGS DPDK_LDFLAGS DPDK_LIBRARIES)

--- a/host/cmake/Modules/UHDConfig.cmake.in
+++ b/host/cmake/Modules/UHDConfig.cmake.in
@@ -21,13 +21,11 @@
 # Allows us to use all .cmake files in this directory
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}")
 
-# set that this file was found, for use in GNU Radio's FindUHD.cmake.
+# Set that this file was found, for use in GNU Radio's FindUHD.cmake.
 # Have to use the ENV, since this file might not allow CACHE changes.
-
 set(ENV{UHD_CONFIG_USED} TRUE)
 
-# set default values
-
+# Set default values
 set(UHD_FOUND TRUE)
 set(UHD_RFNOC_FOUND @UHD_RFNOC_FOUND@)
 set(UHD_INCLUDE_HINTS)
@@ -69,7 +67,6 @@ endif()
 # Verify that <uhd/config.hpp> and libuhd are available, and, if a
 # version is provided, that UHD meets the version requirements -- no
 # matter what pkg-config might think.
-
 find_path(
     UHD_INCLUDE_DIRS
     NAMES uhd/config.hpp
@@ -104,13 +101,9 @@ if(UHD_USE_STATIC_LIBS)
 endif(UHD_USE_STATIC_LIBS)
 
 if(UHD_LIBRARIES AND UHD_INCLUDE_DIRS)
-
   include(FindPackageHandleStandardArgs)
   FIND_PACKAGE_HANDLE_STANDARD_ARGS(UHD DEFAULT_MSG UHD_LIBRARIES UHD_INCLUDE_DIRS)
   mark_as_advanced(UHD_LIBRARIES UHD_INCLUDE_DIRS)
-
 elseif(UHD_FIND_REQUIRED)
-
   message(FATAL_ERROR "UHD is required, but was not found.")
-
 endif()

--- a/host/include/uhd/rfnoc/chdr_types.hpp
+++ b/host/include/uhd/rfnoc/chdr_types.hpp
@@ -709,7 +709,10 @@ public:
         : _op_code(op_code), _op_payload(op_payload), _ops_pending(ops_pending)
     {
     }
+
     mgmt_op_t(const mgmt_op_t& rhs) = default;
+    mgmt_op_t& operator=(const mgmt_op_t& rhs) = default;
+
 
     //! Get the ops pending for this transaction
     //  Note that ops_pending is not used by UHD, since it can infer this value

--- a/host/lib/CMakeLists.txt
+++ b/host/lib/CMakeLists.txt
@@ -17,39 +17,39 @@ macro(LIBUHD_APPEND_LIBS)
 endmacro(LIBUHD_APPEND_LIBS)
 
 macro(LIBUHD_PYTHON_GEN_SOURCE pyfile outfile)
-    #ensure that the directory exists for outfile
+    # Ensure that the directory exists for outfile
     get_filename_component(outfile_dir ${outfile} PATH)
     file(MAKE_DIRECTORY ${outfile_dir})
 
-    #make the outfile depend on the python script
+    # Make the outfile depend on the python script
     add_custom_command(
         OUTPUT ${outfile} DEPENDS ${pyfile} ${LIBUHD_PYTHON_GEN_SOURCE_DEPS}
         COMMAND ${PYTHON_EXECUTABLE} -B ${pyfile} ${outfile}
         COMMENT "Generating ${outfile}"
     )
 
-    #make libuhd depend on the outfile
+    # Make libuhd depend on the outfile
     LIBUHD_APPEND_SOURCES(${outfile})
 endmacro(LIBUHD_PYTHON_GEN_SOURCE)
 
 macro(INCLUDE_SUBDIRECTORY subdir)
-    #insert the current directories on the front of the list
+    # Insert the current directories on the front of the list
     list(INSERT _cmake_source_dirs 0 ${CMAKE_CURRENT_SOURCE_DIR})
     list(INSERT _cmake_binary_dirs 0 ${CMAKE_CURRENT_BINARY_DIR})
 
-    #set the current directories to the names of the subdirs
+    # Set the current directories to the names of the subdirs
     set(CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${subdir})
     set(CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${subdir})
 
-    #include the subdirectory CMakeLists to run it
+    # Include the subdirectory CMakeLists to run it
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     include(${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
 
-    #reset the value of the current directories
+    # Reset the value of the current directories
     list(GET _cmake_source_dirs 0 CMAKE_CURRENT_SOURCE_DIR)
     list(GET _cmake_binary_dirs 0 CMAKE_CURRENT_BINARY_DIR)
 
-    #pop the subdir names of the front of the list
+    # Pop the subdir names of the front of the list
     list(REMOVE_AT _cmake_source_dirs 0)
     list(REMOVE_AT _cmake_binary_dirs 0)
 endmacro(INCLUDE_SUBDIRECTORY)
@@ -229,7 +229,7 @@ if(ENABLE_SIM)
 
 endif(ENABLE_SIM)
 
-if(NOT UHDHOST_PKG) #Syntax makes it unusable by UHD_INSTALL
+if(NOT UHDHOST_PKG) # Syntax makes it unusable by UHD_INSTALL
     install(TARGETS uhd
         LIBRARY DESTINATION ${LIBRARY_DIR} COMPONENT libraries # .so file
         ARCHIVE DESTINATION ${LIBRARY_DIR} COMPONENT libraries # .lib file

--- a/host/lib/rfnoc/radio_control_impl.cpp
+++ b/host/lib/rfnoc/radio_control_impl.cpp
@@ -244,7 +244,6 @@ radio_control_impl::radio_control_impl(make_args_ptr make_args)
         add_property_resolver({&_samp_rate_in.back(), &_samp_rate_out.back()},
             {&_samp_rate_in.back(), &_samp_rate_out.back()},
             [this,
-                chan,
                 &samp_rate_in  = _samp_rate_in.at(chan),
                 &samp_rate_out = _samp_rate_out.at(chan)]() {
                 UHD_LOGGER_TRACE(this->get_unique_id())

--- a/host/lib/usrp/mpmd/mpmd_link_if_ctrl_udp.cpp
+++ b/host/lib/usrp/mpmd/mpmd_link_if_ctrl_udp.cpp
@@ -248,11 +248,14 @@ size_t discover_mtu(const std::string& address,
         // Only test multiples of 4 bytes!
         const size_t test_frame_size = (max_frame_size / 2 + min_frame_size / 2 + 3)
                                        & ~size_t(3);
+
         // Encode sequence number and current size in the string, makes it
         // easy to debug in code or Wireshark. Is also used for identifying
         // response packets.
-        std::sprintf(
-            &send_buf[echo_prefix_offset], ";%04lu,%04lu", seq_no++, test_frame_size);
+        size_t remaining_size = test_frame_size - echo_prefix_offset;
+        std::snprintf(
+            &send_buf[echo_prefix_offset], remaining_size, ";%04lu,%04lu", seq_no++, test_frame_size);
+        
         UHD_LOG_TRACE("MPMD", "Testing frame size " << test_frame_size);
         udp->send(boost::asio::buffer(&send_buf[0], test_frame_size));
 

--- a/host/lib/utils/thread.cpp
+++ b/host/lib/utils/thread.cpp
@@ -173,6 +173,7 @@ void uhd::set_thread_priority(float, bool)
 void uhd::set_thread_affinity(const std::vector<size_t>& cpu_affinity_list)
 {
     UHD_LOG_DEBUG("UHD", "Setting thread affinity is not implemented");
+    static_cast<void>(cpu_affinity_list);
 }
 #endif /* HAVE_THREAD_SETAFFINITY_DUMMY */
 
@@ -186,6 +187,8 @@ void uhd::set_thread_name(boost::thread* thrd, const std::string& name)
     // before the logger starts, and thus can't log any error messages.
     // Note that CMake will also tell the user about not being able to set
     // thread names.
+    static_cast<void>(thrd);
+    static_cast<void>(name);
 #endif /* HAVE_THREAD_SETNAME_DUMMY */
 }
 
@@ -199,5 +202,7 @@ void uhd::set_thread_name(std::thread* thrd, const std::string& name)
     // before the logger starts, and thus can't log any error messages.
     // Note that CMake will also tell the user about not being able to set
     // thread names.
+    static_cast<void>(thrd);
+    static_cast<void>(name);
 #endif /* HAVE_THREAD_SETNAME_DUMMY */
 }


### PR DESCRIPTION
# Pull Request Details
I extracted these changes from my other MR that was closed just now (https://github.com/EttusResearch/uhd/pull/679) without any changes to the examples.  The original changes were made over a year ago and after rebasing a few of the fixes done there have already been committed in other MRs. What remains is rather little, so should hopefully pose no problems to merge

## Description
Basically, after rebasing onto the current version of uhd, here's what these changes still entail:

- `install_name` wasnt manually set in CMake, which caused a warning in newer CMake versions due to breaking 
- Version range in DPDK find package module wasnt handled properly. Fixed by simply adding `HANDLE_VERSION_RANGE` flag
- Substituted use of sprintf with safer and more idiomatic snprintf variant
- Included boost as System dependency. This effectively suppresses compiler warnings from included boost headers so one can focus on the uhd ones
- Fixed compiler warnings (unused variables and missing copy assignment)
- Some minor comment formatting improvements for readability.


## Which devices/areas does this affect?
Minor changes to the build system and the host library.

## Testing Done
Since this affects mainly the build system, testing was building and verifying that CMake and compiler warnings were fixed.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
