### PR TITLE
image_builder.py: Do not use os.system, as it encodes the return value

### DIFF
--- a/fpga/usrp3/tools/utils/repeat_fpga_build.py
+++ b/fpga/usrp3/tools/utils/repeat_fpga_build.py
@@ -436,7 +436,7 @@ def run_ip_build(
     logging.info(f"Running IP build with command: {cmd}")
     output = ""
     with subprocess.Popen(
-        f'/bin/bash -c "{cmd}"',
+        cmd,
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/host/python/uhd/rfnoc_utils/image_builder.py
+++ b/host/python/uhd/rfnoc_utils/image_builder.py
@@ -31,9 +31,6 @@ from .template import Template
 
 USRP3_LIB_RFNOC_DIR = os.path.join("usrp3", "lib", "rfnoc")
 
-# Path to the system's bash executable
-BASH_EXECUTABLE = "/bin/bash"  # FIXME this should come from somewhere
-
 # Map device names to the corresponding directory under usrp3/top
 DEVICE_DIR_MAP = {
     "x300": "x300",
@@ -86,7 +83,7 @@ def get_vivado_path(fpga_top_dir, args):
         get_viv_path_cmd = '. ./setupenv.sh && echo "VIVADO_PATH=\$VIVADO_PATH"'
         try:
             output = subprocess.check_output(
-                f'{BASH_EXECUTABLE} -c "{get_viv_path_cmd}"',
+                get_viv_path_cmd,
                 shell=True,
                 cwd=fpga_top_dir,
                 text=True,
@@ -289,8 +286,6 @@ def build(fpga_top_dir, device, build_dir, use_secure_netlist, **args):
     logging.info(" * Build Artifacts Directory: %s", build_dir)
     logging.info(" * Build Output Directory: %s", build_output_dir)
     logging.info(" * Build IP Directory: %s", build_ip_dir)
-    # Wrap it into a bash call:
-    make_cmd = f'{BASH_EXECUTABLE} -c "{make_cmd}"'
     logging.info("Executing the following command: %s", make_cmd)
     my_env = os.environ.copy()
     ret_val = subprocess.call(make_cmd, shell=True, env=my_env, cwd=fpga_top_dir)

--- a/host/python/uhd/rfnoc_utils/image_builder.py
+++ b/host/python/uhd/rfnoc_utils/image_builder.py
@@ -290,14 +290,12 @@ def build(fpga_top_dir, device, build_dir, use_secure_netlist, **args):
     logging.info(" * Build Output Directory: %s", build_output_dir)
     logging.info(" * Build IP Directory: %s", build_ip_dir)
     # Wrap it into a bash call:
-    logging.debug("Temporarily changing working directory to %s", fpga_top_dir)
-    os.chdir(fpga_top_dir)
     make_cmd = f'{BASH_EXECUTABLE} -c "{make_cmd}"'
     logging.info("Executing the following command: %s", make_cmd)
-    ret_val = os.system(make_cmd)
+    my_env = os.environ.copy()
+    ret_val = subprocess.call(make_cmd, shell=True, env=my_env, cwd=fpga_top_dir)
     if ret_val == 0 and args.get("secure_core"):
         patch_netlist_constraints(device, build_dir)
-    os.chdir(cwd)
     return ret_val
 
 


### PR DESCRIPTION
# Pull Request Details

## Description

os.system's return value is the process's return value, but encoded in the wait format on Linux which means, that the result is multiplied by 256. Thus a return value of 1 of the executed command results in a ret_val of 256, an return value of 2 means 512, and so on. If this value is forwarded without further handling, and naively used as "normal" exit status, then the value overflows and always results in a 0 exit code.

Instead of implementing a Windows/Linux dependant workaround, using subprocess instead of os.system is better anyway, as the usage of os.system is discouraged.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
I have built the X3x0 design with various failures on purpose.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes, and all previous tests pass.
- [x] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
