### PR TITLE
host: include cstdint before boost/lockfree/queue.hpp

### DIFF
--- a/host/cmake/Modules/UHDAtomics.cmake
+++ b/host/cmake/Modules/UHDAtomics.cmake
@@ -38,6 +38,7 @@ endfunction(CHECK_WORKING_CXX_ATOMICS64)
 function(CHECK_WORKING_CXX_BOOST_ATOMICS varname)
     set(CMAKE_REQUIRED_INCLUDES ${Boost_INCLUDE_DIRS})
     CHECK_CXX_SOURCE_COMPILES("
+        #include <cstdint>
         #include <boost/lockfree/queue.hpp>
         boost::lockfree::queue<int> queue(1);
         int main() {

--- a/host/lib/include/uhdlib/rfnoc/tx_async_msg_queue.hpp
+++ b/host/lib/include/uhdlib/rfnoc/tx_async_msg_queue.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <uhd/types/metadata.hpp>
+#include <cstdint>
 #include <boost/lockfree/queue.hpp>
 
 namespace uhd { namespace rfnoc {

--- a/host/lib/transport/offload_io_service.cpp
+++ b/host/lib/transport/offload_io_service.cpp
@@ -12,6 +12,7 @@
 #include <uhdlib/transport/offload_io_service_client.hpp>
 #include <uhdlib/utils/semaphore.hpp>
 #include <condition_variable>
+#include <cstdint>
 #include <boost/lockfree/queue.hpp>
 #include <atomic>
 #include <chrono>


### PR DESCRIPTION
cmake will fail when checking CHECK_WORKING_CXX_BOOST_ATOMICS
 without "#include <cstdint>".  And the same with other two c++ files.


