### PR TITLE
cmake: bump min in CMakeRC to work with CMake 4.0

### DIFF
--- a/host/cmake/Modules/CMakeRC.cmake
+++ b/host/cmake/Modules/CMakeRC.cmake
@@ -60,7 +60,7 @@ endif()
 
 set(_version 2.0.0)
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.12)
 include(CMakeParseArguments)
 
 if(COMMAND cmrc_add_resource_library)


### PR DESCRIPTION
# Pull Request Details

## Description
CMake 4.0.0 has removed compatibility with versions older than 3.5. This tries to uplift the minimum to match the base version in CMakeLists.txt

See https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version

## Related Issue
n/a

## Which devices/areas does this affect?
CMake build system

## Testing Done
Currently tried compiling.

Will need verification of newer policies applied are compatible. For lower impact, could go with 3.5 though CMake has deprecated < 3.10 so same issue will happen in future release.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
