### PR TITLE
examples: update for upcoming Boost 1.88.0

### DIFF
--- a/host/examples/rx_samples_to_file.cpp
+++ b/host/examples/rx_samples_to_file.cpp
@@ -15,7 +15,15 @@
 #include <boost/program_options.hpp>
 #ifdef __linux__
 #    include <boost/filesystem.hpp>
-#    include <boost/process.hpp>
+#    include <boost/version.hpp>
+#    if BOOST_VERSION >= 108800
+#        define BOOST_PROCESS_VERSION 1
+#        include <boost/process/v1/child.hpp>
+#        include <boost/process/v1/io.hpp>
+#        include <boost/process/v1/pipe.hpp>
+#    else
+#        include <boost/process.hpp>
+#    endif
 #endif
 #include <chrono>
 #include <complex>


### PR DESCRIPTION
# Pull Request Details

## Description
Boost.Process 1.88.0 will make `boost::process::v2` the default which breaks compilation of rx_samples_to_file.cpp. This change uses v1 headers and inline namespace to fix build.

See https://github.com/boostorg/process/commit/2ccd97cd48c5468b0609a488b59253efaa381711

I didn't see a single header that enabled v1 process.

## Related Issue
n/a

## Which devices/areas does this affect?
Building examples

## Testing Done
Currently checked compilation is successful. The behavior of Boost.Process v1 should still be the same, just that it isn't possible to enable it via main `boost/process.hpp` - https://github.com/boostorg/process/blob/develop/include/boost/process.hpp

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
