### PR TITLE
if_addrs: revert address and mask cast back to ulong

### DIFF
--- a/host/lib/transport/if_addrs.cpp
+++ b/host/lib/transport/if_addrs.cpp
@@ -50,8 +50,8 @@ std::vector<uhd::transport::if_addrs_t> uhd::transport::get_if_addrs(void)
                        == boost::asio::ip::address_v4(0)) {
                 // manually calculate broadcast address
                 // https://svn.boost.org/trac/boost/ticket/5198
-                const uint32_t addr  = sockaddr_to_ip_addr(iter->ifa_addr).to_uint();
-                const uint32_t mask  = sockaddr_to_ip_addr(iter->ifa_netmask).to_uint();
+                const uint32_t addr  = sockaddr_to_ip_addr(iter->ifa_addr).to_ulong();
+                const uint32_t mask  = sockaddr_to_ip_addr(iter->ifa_netmask).to_ulong();
                 const uint32_t bcast = (addr & mask) | ~mask;
                 if_addr.bcast        = boost::asio::ip::address_v4(bcast).to_string();
             }


### PR DESCRIPTION
# Pull Request Details
## Description
this change was introduced in https://github.com/EttusResearch/uhd/commit/adfe953d965e58b5931c1b1968899492c8087cf6 casting to integer makes get_if_addrs crash when called with a LTE modem attached and a bearer active

## Which devices/areas does this affect?
tested on Debian Trixie with a Mediatek M70 5G modem, firmware revision MOLY.NR15.R3.MP.V124.6.P5, CCMNI net driver

## Testing Done
testing was done between the two versions with a bearer active and inactive without an ip acddress on the ccmni interface. it should not affect anything else since there is no api breaking change here

## Checklist

- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
