### PR TITLE
wordfree() calls memory deallocation failure when wordexp() fails

### DIFF
--- a/host/lib/utils/pathslib.cpp
+++ b/host/lib/utils/pathslib.cpp
@@ -48,7 +48,7 @@ std::string uhd::path_expandvars(const std::string& path)
         return_value = std::string(p.we_wordv[0]);
         wordfree(&p);
     } else {
-        if (err == WRDE_NOSPACE)
+        if (err == 0 || err == WRDE_NOSPACE)
             wordfree(&p);
         return_value = path;
     }

--- a/host/lib/utils/pathslib.cpp
+++ b/host/lib/utils/pathslib.cpp
@@ -43,12 +43,15 @@ std::string uhd::path_expandvars(const std::string& path)
 #else
     wordexp_t p;
     std::string return_value;
-    if (wordexp(path.c_str(), &p, 0) == 0 && p.we_wordc > 0) {
+    int err = wordexp(path.c_str(), &p, 0);
+    if (err == 0 && p.we_wordc > 0) {
         return_value = std::string(p.we_wordv[0]);
+        wordfree(&p);
     } else {
+        if (err == WRDE_NOSPACE)
+            wordfree(&p);
         return_value = path;
     }
-    wordfree(&p);
     return return_value;
 #endif
 }


### PR DESCRIPTION

# Pull Request Details
On macOS (and probably other systems), if `wordexp()` fails and one
calls `wordfree()` then this can result in a memory deallocation failure
as the memory was never allocated.

## Description
The change simply does not call `wordfree()` unless `wordexp()` is
successful or the error code `WRDE_NOSPACE`. This follows
the code example given by GNU:
https://www.gnu.org/software/libc/manual/html_node/Wordexp-Example.html

## Related Issue
N/A

## Which devices/areas does this affect?
This is USRP independent. The failure has at least been demonstrated
on macOS.

## Testing Done
To cause the failure, I put the dynamic library inside of a sandbox. This
resulted in the path not being able to be parsed for the config file.
This should result in other areas of code being changed as the function
return logic is identical to before the commit. Test code was not included
as the method for which I tested required XCode, and I felt that would
be unnecessarily complicated to implement for a relatively minor
and small change.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [n/a] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [n/a] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
