### PR TITLE
cmake: support absolute paths for install dirs in pkg-config

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -559,6 +559,18 @@ if(CMAKE_CROSSCOMPILING)
     set(UHD_PC_LIBS)
 endif(CMAKE_CROSSCOMPILING)
 
+# Support absolute paths for LIBDIR and INCLUDEDIR
+if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+    set(UHD_PC_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+else()
+    set(UHD_PC_LIBDIR "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+endif()
+if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(UHD_PC_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+else()
+    set(UHD_PC_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/uhd.pc.in
     ${CMAKE_CURRENT_BINARY_DIR}/uhd.pc

--- a/host/uhd.pc.in
+++ b/host/uhd.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@UHD_PC_LIBDIR@
+includedir=@UHD_PC_INCLUDEDIR@
 
 Name: @CPACK_PACKAGE_NAME@
 Description: @CPACK_PACKAGE_DESCRIPTION_SUMMARY@


### PR DESCRIPTION
The GNUInstallDirs module supports absolute paths for CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_INCLUDEDIR. Some package managers like Nix depend on this behaviour. See https://github.com/NixOS/nixpkgs/issues/144170 for the nixpkgs tracking issue.

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
The switch to GNUInstallDirs in https://github.com/EttusResearch/uhd/commit/6a4a1650aaec9601bda7684c65d3045f8e8caf0e broke packaging for Nix/NixOS. This fixes it by checking whether the install dirs are absolute or relative parts. A better solution would be to use `cmake_path` as described here: https://github.com/jtojnar/cmake-snips/#concatenating-paths-when-building-pkg-config-files.  `cmake_path` is only available from CMake 3.20.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
https://github.com/NixOS/nixpkgs/issues/144170
https://github.com/NixOS/nixpkgs/pull/440695

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I ran a build with `-install-prefix` and verified the result.
I ran a nix build.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
