### PR TITLE
ad9361: fix rounding bug on RF PLL tuning calculations

### DIFF
--- a/host/lib/usrp/common/ad9361_driver/ad9361_device.cpp
+++ b/host/lib/usrp/common/ad9361_driver/ad9361_device.cpp
@@ -1316,10 +1316,12 @@ double ad9361_device_t::_tune_helper(direction_t direction, const double value)
         throw uhd::runtime_error("[ad9361_device_t] RFVCO can't find valid VCO rate!");
 
     int nint  = static_cast<int>(vcorate / fref);
-    int nfrac = static_cast<int>(((vcorate / fref) - nint) * modulus);
+    int nfrac = static_cast<int>(
+        std::lround(((vcorate / fref) - (double)nint) * (double)modulus));
 
-    double actual_vcorate = fref * (nint + (double)(nfrac) / modulus);
-    double actual_lo      = actual_vcorate / vcodiv;
+    double actual_vcorate =
+        fref * ((double)nint + ((double)nfrac / (double)modulus));
+    double actual_lo      = actual_vcorate / (double)vcodiv;
 
     if (direction == RX) {
         _req_rx_freq = value;


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
When an AD9361-based radio changes its RX frequency by 100 MHz or more, a rounding bug in the hardware driver causes the TX RF PLL frequency to decrease by one LO step. The error is cumulative, potentially causing the TX frequency to drift further with subsequent large RX frequency changes. For RFNoC-based radios, the true TX frequency is also not reported correctly by the API because it returns a locally cached value.

Example:
1. Application requests TX frequency 926500000 Hz.
2. Based on PLL quantized step size, TX RF PLL is set to 926499999.46 Hz.
3. Application requests RX frequency 926500000 Hz.
4. Based on PLL quantized step size, RX RF PLL is set to 926499999.46 Hz.
5. During RX re-tune, TX RF PLL is accidentally reconfigured to 926499998.27 Hz (reduced by one LO step size, i.e. 1.1921 Hz at this frequency).
6. If application queries TX frequency, the original value of 926499999.46 is returned although the RFIC TX is now operating at 926499998.27.

The root cause is a rounding bug in _tune_helper() in ad9361_device.cpp. When the RX PLL is changed by 100MHz or more, it calls _calibrate_rx_quadrature() after re-tuning. This function briefly changes the TX PLL frequency and then attempts to restore it by calling _tune_helper with the original actual LO value. Due to floating-point representation and integer truncation, when _tune_helper() is given a desired frequency that is an exact step such as happens here, it calculates a PLL fractional value that is one step too low. Each time RX is re-tuned by at least 100MHz, the TX frequency will drop by another LO step. This error cannot be detected with the API to query the TX frequency, because the RFNoC radio control module returns a cached value of what it expects the TX RF frequency to be, not realizing it was unexpectedly changed by the RX re-tuning.

The fix is to perform rounding when determining the PLL fractional value. This is implemented correctly by the driver for the BB PLL, so I copied the same logic to the RF PLL for consistency (which is why explicit casts are also added by the patch).
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes, and all previous tests pass.
- [X] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
