### PR TITLE
Cal: Fix default E320 LO offset to keep signal within passband

### DIFF
--- a/host/python/uhd/usrp/cal/usrp_calibrator.py
+++ b/host/python/uhd/usrp/cal/usrp_calibrator.py
@@ -416,10 +416,10 @@ class E3XXCalibrator(USRPCalibratorBase):
     # Choosing 4 MHz: It is a small rate, but carries enough bandwidth to receive
     # a tone. Compatible with the default MCR of 16 MHz.
     default_rate = 4e6
-    # Choosing an LO offset of 8 MHz: At 4 Msps, the LO will never be within
+    # Choosing an LO offset of 5 MHz: At 4 Msps, the LO will never be within
     # our estimate. E3XX generally has good DC offset / IQ balance performance,
     # but we still try and avoid DC as much as possible.
-    lo_offset = 8e6
+    lo_offset = 5e6
     tune_settling_time = .01 # Probably not needed??
 
     def __init__(self, usrp, meas_dev, direction, **kwargs):


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->
The power calibrator code is setting a combination sample rate and LO offset that are invalid for the default master_clock_rate of 16MHz, so the logic does not work properly (tuned frequency is coerced) unless master_clock_rate is overridden in args. This PR adjusts the LO offset to still be out of the signal passband, but within the valid range for the default master_clock_rate.

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->
Affects power calibration utility for E3xx only.

## Testing Done
Performed power calibration of E320 unit.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
