### PR TITLE
Cal: Fix support for non-default sampling rate when using USRP as signal source

### DIFF
--- a/host/python/uhd/usrp/cal/meas_device.py
+++ b/host/python/uhd/usrp/cal/meas_device.py
@@ -292,6 +292,7 @@ class USRPPowerGenerator(SignalGeneratorBase):
         self._amplitude = float(options.get('ampl', 1/numpy.sqrt(2)))
         self._pwr_dbfs = 20 * numpy.log10(self._amplitude)
         self._tone_freq = 0
+        self._usrp.set_tx_rate(self._rate, self._chan)
         stream_args = uhd.usrp.StreamArgs('fc32', 'sc16')
         stream_args.channels = [self._chan]
         self._streamer = self._usrp.get_tx_stream(stream_args)


### PR DESCRIPTION
When using uhd_power_cal.py to perform RX calibration where the signal generator is a TX-calibrated USRP, the transmitter sample rate can be changed on the command-line using a syntax such as "--meas-option rate=4e6". This argument is extracted by the USRPPowerGenerator class, but never actually set on the TX USRP object.

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
Affects RX power calibration utility when using a TX-calibrated USRP as the signal source, and non-default TX sample rate.
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
Performed RX calibration of USRP E320 under this scenario.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
