### PR TITLE
Cal: Fix missing input power clamp during RX power calibration

### DIFF
--- a/host/python/uhd/usrp/cal/usrp_calibrator.py
+++ b/host/python/uhd/usrp/cal/usrp_calibrator.py
@@ -291,7 +291,8 @@ class USRPCalibratorBase:
                 power_delta = PWR_EST_IDEAL_LEVEL - recvd_power
                 self.log("Adapting input power to: {:+.2f} dBm."
                          .format(usrp_input_power + power_delta))
-                usrp_input_power = self._meas_dev.set_power(usrp_input_power + power_delta)
+                usrp_input_power = self._meas_dev.set_power(
+                    min(usrp_input_power + power_delta, self.max_input_power))
                 self.log("New input power is: {:+.2f} dBm".format(usrp_input_power))
                 # And then of course, measure again
                 recvd_power = get_usrp_power(self._streamer)


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `product: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters, and other lines to 72 -->
<!--- characters. Refer to the "Revision Control Hygiene" section -->
<!--- CODING.md for more details. -->
When doing RX power calibration, the primary loop in run_rx_cal() has two locations where it adjusts the TX output power: one when stepping the RX gain, and another when the received signal power is outside the desired bounds. The first case has a clamp to ensure it does not request a TX output level that would be above "max_input_power". The second case was missing this clamping.

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which devices/areas does this affect?
Affects RX power calibration utility
<!--- Include devices that are affected and some details on what -->
<!--- areas these changes affect, such as RF performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
