### PR TITLE
Include gps_iface.hpp in CMakeLists.txt install directive

### DIFF
--- a/host/include/uhd/features/CMakeLists.txt
+++ b/host/include/uhd/features/CMakeLists.txt
@@ -14,6 +14,7 @@ UHD_INSTALL(FILES
     trig_io_mode_iface.hpp
     internal_sync_iface.hpp
     complex_gain_iface.hpp
+    gps_iface.hpp
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uhd/features
     COMPONENT headers
 )


### PR DESCRIPTION
# Pull Request Details
gps_iface.hpp included in CMakeLists.txt install directive.
Previously was not installed, and so a system installation of UHD did not have the headers available for use.

## Testing Done
CMake still runs, and successfully installs gps_iface.hpp into the include folder.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
