### PR TITLE
rfnoc: ddc/duc: fix valid decim/interp calculation

### DIFF
--- a/host/lib/rfnoc/ddc_block_control.cpp
+++ b/host/lib/rfnoc/ddc_block_control.cpp
@@ -80,7 +80,7 @@ public:
 
         // Load list of valid decimation values
         std::set<size_t> decims{1}; // 1 is always a valid decimation
-        for (size_t hb = 0; hb < _num_halfbands; hb++) {
+        for (size_t hb = 0; hb <= _num_halfbands; hb++) {
             for (size_t cic_decim = 1; cic_decim <= _cic_max_decim; cic_decim++) {
                 decims.insert((1 << hb) * cic_decim);
             }

--- a/host/lib/rfnoc/duc_block_control.cpp
+++ b/host/lib/rfnoc/duc_block_control.cpp
@@ -79,7 +79,7 @@ public:
         set_mtu_forwarding_policy(forwarding_policy_t::ONE_TO_ONE);
         // Load list of valid interpolation values
         std::set<size_t> interps{1}; // 1 is always a valid interpolation
-        for (size_t hb = 0; hb < _num_halfbands; hb++) {
+        for (size_t hb = 0; hb <= _num_halfbands; hb++) {
             for (size_t cic_interp = 1; cic_interp <= _cic_max_interp; cic_interp++) {
                 interps.insert((1 << hb) * cic_interp);
             }


### PR DESCRIPTION
The current calculation of the valid decimation and interpolation values ignores the last available HB filter. 

Example:
When DUC is configured to `CIC_MAX_INTERP=128`, `NUM_HB=2` we get those ranges:
`1..128`     - `step=1`: uses CIC only
`130..256` - `step=2`: uses CIC and 1 HB
But we dont get the last range that uses the last HB:
`260..512` - `step=4`: uses CIC and 2 HBs

## Which devices/areas does this affect?
It affects any design that uses the RFNoC DUC/DDC blocks.
It should enable the usage of another range of interp/decim values that is supported by the hardware on the FPGA.

## Testing Done
Minimal testing on hardware.
It seems like the existing tests only check one value of interpolation/decimation that doesn't require the last HB filter.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
