### PR TITLE
fix to multi-usrp-rfnoc 'set_master_clock_rate' function

### DIFF
--- a/host/lib/usrp/multi_usrp_rfnoc.cpp
+++ b/host/lib/usrp/multi_usrp_rfnoc.cpp
@@ -747,17 +747,33 @@ public:
     void set_master_clock_rate(double rate, size_t mboard) override
     {
         for (auto& chain : _rx_chans) {
-            auto radio = chain.second.radio;
+            auto& rx_chain = chain.second;
+            auto radio     = rx_chain.radio;
             if (radio->get_block_id().get_device_no() == mboard
                 || mboard == ALL_MBOARDS) {
-                radio->set_rate(rate);
+                const double actual_radio_rate = radio->set_rate(rate);
+                if (rx_chain.ddc) {
+                    rx_chain.ddc->set_input_rate(actual_radio_rate, rx_chain.block_chan);
+                    if (_rx_rates.count(chain.first)) {
+                        _rx_rates[chain.first] = rx_chain.ddc->set_output_rate(
+                            _rx_rates.at(chain.first), rx_chain.block_chan);
+                    }
+                }
             }
         }
         for (auto& chain : _tx_chans) {
-            auto radio = chain.second.radio;
+            auto& tx_chain = chain.second;
+            auto radio     = tx_chain.radio;
             if (radio->get_block_id().get_device_no() == mboard
                 || mboard == ALL_MBOARDS) {
-                radio->set_rate(rate);
+                const double actual_radio_rate = radio->set_rate(rate);
+                if (tx_chain.duc) {
+                    tx_chain.duc->set_output_rate(actual_radio_rate, tx_chain.block_chan);
+                    if (_tx_rates.count(chain.first)) {
+                        _tx_rates[chain.first] = tx_chain.duc->set_input_rate(
+                            _tx_rates.at(chain.first), tx_chain.block_chan);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
`RFNoC`s `multi_usrp` did not fully propagate `set_master_clock_rate()` to the DUC/DDC chain.

Before this change, `set_master_clock_rate()` updated only the radio rate. If a channel had a DUC or DDC, the adjacent converter rate was left stale:
- TX: the DUC output rate was not updated to the new radio rate
- RX: the DDC input rate was not updated to the new radio rate

That caused follow-up `set_tx_rate()` / `set_rx_rate()` calls on the same `multi_usrp` object to operate on outdated DUC/DDC state. In practice, after changing the master clock, setting the channel sample rate could be coerced unexpectedly because interpolation/decimation was derived from the old converter-side rate.

This change updates `multi_usrp_rfnoc` so that `set_master_clock_rate()`:
- propagates the new radio rate to the attached DUC/DDC
- reapplies the previously requested per-channel TX/RX rate so the DUC/DDC continues to follow the user-requested sample rate

## Which devices/areas does this affect?
`multi_usrp_rfnoc` object functionality.

## Testing Done
Initialized `multi_usrp` with `master_clock_rate=12.345e6`
set_master_clock_rate(10e6)
set_tx_rate(1e6) // <- before this change, this was unexpectedly coerced even though the new master clock(10e6) should be interpolated by 10.

After the change, there is no coercion.

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)