### PR TITLE
Stop coherent ctrl port write overwriting the most significant word with unused cache.

### DIFF
--- a/fpga/usrp3/lib/rfnoc/utils/ctrlport_reg_rw.v
+++ b/fpga/usrp3/lib/rfnoc/utils/ctrlport_reg_rw.v
@@ -157,7 +157,7 @@ module ctrlport_reg_rw #(
               end
 
               // Update the least-significant words from the cache
-              for (w = 0; w < NUM_BYTES/4; w = w+1) begin
+              for (w = 0; w < NUM_BYTES/4-1; w = w+1) begin
                 if (write_en_cache_reg[b]) begin
                   reg_val[32*w+b*8 +: 8] <= write_cache_reg[32*w+b*8 +: 8];
                 end


### PR DESCRIPTION
# Pull Request Details
Fix bug in fpga/usrp3/lib/rfnoc/utils/ctrlport_reg_rw.v which overwrites the most significant word with zeros from the cache. Fix makes behaviour consistent with lines 154-156.

## Description
Line 156:
`reg_val[32*(NUM_BYTES/4-1)+b*8 +: 8] <= s_ctrlport_req_data[8*b +: 8];`
sets the bits for the word `NUM_BYTES/4-1`

But line 160 counts up to less than  `NUM_BYTES/4` which of course includes `NUM_BYTES/4-1`.
This causes the most significant word to be set to zero (as the cache value is never set) instead of the intended value from line 156.

## Which devices/areas does this affect?
Coherent register writes.

## Testing Done
Did coherent writes on a custom RFNoC Block on an N320.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project. See CODING.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes, and all previous tests pass.
- [ ] I have checked all compat numbers if they need updating (FPGA compat,
      MPM compat, noc_shell, specific RFNoC block, ...)
